### PR TITLE
Allow content type to have empty reference field

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -131,7 +131,7 @@ var builtEntry = function builtEntry(schema, entry, locale, entries, createNodeI
         var value = typeof entry[field.uid] != 'undefined' ? entry[field.uid] : null;
         switch (field.data_type) {
             case "reference":
-                entryObj[field.uid + "___NODE"] = normalizeReferenceField(value, field.reference_to, locale, entries[field.reference_to], createNodeId);
+                entryObj[field.uid + "___NODE"] = value && normalizeReferenceField(value, field.reference_to, locale, entries[field.reference_to], createNodeId);
                 break;
             case "group":
                 entryObj[field.uid] = normalizeGroup(field, value, locale, entries, createNodeId);

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -106,7 +106,7 @@ const normalizeReferenceField = (value, referenceTo, locale, entries,  createNod
                         reference.push(createNodeId(`contentstack-entry-${entryUid}-${publishedLocale}`));
                     }
                 });
-         
+            
     });
     return reference;
 }
@@ -118,7 +118,7 @@ const builtEntry = (schema, entry, locale, entries, createNodeId) => {
         let value = (typeof entry[field.uid] != 'undefined') ? entry[field.uid] : null;
         switch (field.data_type) {
             case "reference":
-                entryObj[`${field.uid}___NODE`] = normalizeReferenceField(value, field.reference_to, locale, entries[field.reference_to], createNodeId);
+                entryObj[`${field.uid}___NODE`] = value && normalizeReferenceField(value, field.reference_to, locale, entries[field.reference_to], createNodeId);
             break;
             case "group":
                 entryObj[field.uid] = normalizeGroup(field, value, locale, entries, createNodeId);


### PR DESCRIPTION
We were having an issue where empty reference fields were causing Gatsby to crash.

This little fix just prevents running `normalizeReferenceField` when the value for an entry is `null`