### PR TITLE
Check variable types before use in normalize.js

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -1,5 +1,9 @@
 "use strict";
 
+var _typeof2 = require("babel-runtime/helpers/typeof");
+
+var _typeof3 = _interopRequireDefault(_typeof2);
+
 var _keys = require("babel-runtime/core-js/object/keys");
 
 var _keys2 = _interopRequireDefault(_keys);
@@ -88,7 +92,9 @@ var normalizeGroup = function normalizeGroup(field, value, locale, entries, crea
 };
 
 var normalizeModularBlock = function normalizeModularBlock(blocks, value, locale, entries, createNodeId) {
-    var modularBlocksObj = [];
+    var modularBlocksArray = [];
+    if (!Array.isArray(value)) return modularBlocksArray;
+
     value.map(function (block) {
         (0, _keys2.default)(block).forEach(function (key) {
             var blockSchema = blocks.filter(function (block) {
@@ -96,10 +102,11 @@ var normalizeModularBlock = function normalizeModularBlock(blocks, value, locale
             });
             var blockObj = {};
             blockObj[key] = builtEntry(blockSchema[0].schema, block[key], locale, entries, createNodeId);
-            modularBlocksObj.push(blockObj);
+            modularBlocksArray.push(blockObj);
         });
     });
-    return modularBlocksObj;
+
+    return modularBlocksArray;
 };
 
 var normalizeReferenceField = function normalizeReferenceField(value, referenceTo, locale, entries, createNodeId) {
@@ -125,10 +132,16 @@ var normalizeReferenceField = function normalizeReferenceField(value, referenceT
     return reference;
 };
 
+var getSchemaValue = function getSchemaValue(obj, key) {
+    if (obj === null) return null;
+    if ((typeof obj === "undefined" ? "undefined" : (0, _typeof3.default)(obj)) !== "object") return null;
+    return obj.hasOwnProperty(key.uid) ? obj[key.uid] : null;
+};
+
 var builtEntry = function builtEntry(schema, entry, locale, entries, createNodeId) {
     var entryObj = {};
     schema.forEach(function (field) {
-        var value = typeof entry[field.uid] != 'undefined' ? entry[field.uid] : null;
+        var value = getSchemaValue(entry, field);
         switch (field.data_type) {
             case "reference":
                 entryObj[field.uid + "___NODE"] = value && normalizeReferenceField(value, field.reference_to, locale, entries[field.reference_to], createNodeId);

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -77,16 +77,19 @@ const normalizeGroup = (field, value, locale, entries, createNodeId) => {
 };
 
 const normalizeModularBlock = (blocks, value, locale, entries, createNodeId) => {
-    let modularBlocksObj = [];
+    const modularBlocksArray = [];
+    if (!Array.isArray(value)) return modularBlocksArray;
+
     value.map(block => {
         Object.keys(block).forEach(key => {
-            let blockSchema = blocks.filter(block => block.uid ===  key);
-            let blockObj = {};
-            blockObj[key] =  builtEntry(blockSchema[0].schema, block[key], locale, entries, createNodeId);
-            modularBlocksObj.push(blockObj);
+            const blockSchema = blocks.filter(block => block.uid ===  key);
+            const blockObj = {};
+            blockObj[key] = builtEntry(blockSchema[0].schema, block[key], locale, entries, createNodeId);
+            modularBlocksArray.push(blockObj);
         });
     });
-    return modularBlocksObj;
+
+    return modularBlocksArray;
 };
 
 const normalizeReferenceField = (value, referenceTo, locale, entries,  createNodeId) => {
@@ -111,11 +114,16 @@ const normalizeReferenceField = (value, referenceTo, locale, entries,  createNod
     return reference;
 }
 
+const getSchemaValue = (obj, key) => {
+    if (obj === null) return null;
+    if (typeof obj !== "object") return null;
+    return obj.hasOwnProperty(key.uid) ? obj[key.uid] : null;
+};
 
 const builtEntry = (schema, entry, locale, entries, createNodeId) => {
 	let entryObj = {};
     schema.forEach(field => {
-        let value = (typeof entry[field.uid] != 'undefined') ? entry[field.uid] : null;
+        const value = getSchemaValue(entry, field);
         switch (field.data_type) {
             case "reference":
                 entryObj[`${field.uid}___NODE`] = value && normalizeReferenceField(value, field.reference_to, locale, entries[field.reference_to], createNodeId);


### PR DESCRIPTION
- check value is array before attempting to map in normalizeModularBlock()
- check value is not null before attempting to access object property in builtEntry()