### PR TITLE
normalizeModularBlock - throws error on missing block schema

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -116,6 +116,10 @@ var normalizeModularBlock = function normalizeModularBlock(blocks, value, locale
             var blockSchema = blocks.filter(function (block) {
                 return block.uid === key;
             });
+            if (!blockSchema.length) {
+                // block value no longer exists block schema so ignore it
+                return;
+            }
             var blockObj = {};
             blockObj[key] = builtEntry(blockSchema[0].schema, block[key], locale, entriesNodeIds, assetsNodeIds, createNodeId);
             modularBlocksObj.push(blockObj);

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -97,6 +97,10 @@ const normalizeModularBlock = (blocks, value, locale, entriesNodeIds, assetsNode
     value.map(block => {
         Object.keys(block).forEach(key => {
             let blockSchema = blocks.filter(block => block.uid ===  key);
+            if (!blockSchema.length) {
+                // block value no longer exists block schema so ignore it
+                return
+            }
             let blockObj = {};
             blockObj[key] =  builtEntry(blockSchema[0].schema, block[key], locale, entriesNodeIds, assetsNodeIds, createNodeId);
             modularBlocksObj.push(blockObj);


### PR DESCRIPTION
Fixed error where module block value missing from module block schema. It would crash on call to `blockSchema[0].schema` because no matching block in block schema was found