### PR TITLE
Bug fix - use publish_details.locale, instead of the origin locale

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -67,31 +67,17 @@ exports.processEntry = function (content_type, entry, createNodeId, createConten
 };
 
 exports.normalizeEntry = function (contentType, entry, entriesNodeIds, assetsNodeIds, createNodeId) {
-    var resolveEntry = (0, _assign2.default)({}, entry, builtEntry(contentType.schema, entry, entry.locale, entriesNodeIds, assetsNodeIds, createNodeId));
+    var resolveEntry = (0, _assign2.default)({}, entry, builtEntry(contentType.schema, entry, entry.publish_details.locale, entriesNodeIds, assetsNodeIds, createNodeId));
     return resolveEntry;
 };
 
 var makeAssetNodeUid = exports.makeAssetNodeUid = function (asset, createNodeId) {
-    var publishedLocale = null;
-    if (asset && asset.publish_details) {
-        if (Array.isArray(asset.publish_details)) {
-            publishedLocale = asset.publish_details[0].locale;
-        } else {
-            publishedLocale = asset.publish_details.locale;
-        }
-    }
+    var publishedLocale = asset.publish_details.locale;
     return createNodeId("contentstack-assets-" + asset.uid + "-" + publishedLocale);
 };
 
 var makeEntryNodeUid = exports.makeEntryNodeUid = function (entry, createNodeId) {
-    var publishedLocale = null;
-    if (entry && entry.publish_details) {
-        if (Array.isArray(entry.publish_details)) {
-            publishedLocale = entry.publish_details[0].locale;
-        } else {
-            publishedLocale = entry.publish_details.locale;
-        }
-    }
+    var publishedLocale = entry.publish_details.locale;
     return createNodeId("contentstack-entry-" + entry.uid + "-" + publishedLocale);
 };
 

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -48,32 +48,18 @@ exports.processEntry = (content_type, entry, createNodeId, createContentDigest) 
 }
 
 exports.normalizeEntry = (contentType, entry, entriesNodeIds, assetsNodeIds, createNodeId) => {
-    let resolveEntry = Object.assign({}, entry, builtEntry(contentType.schema, entry, entry.locale, entriesNodeIds, assetsNodeIds, createNodeId));
+    let resolveEntry = Object.assign({}, entry, builtEntry(contentType.schema, entry, entry.publish_details.locale, entriesNodeIds, assetsNodeIds, createNodeId));
     return resolveEntry;
 }
 
 
 const makeAssetNodeUid = exports.makeAssetNodeUid = (asset, createNodeId) => {
-    let publishedLocale = null;
-    if(asset && asset.publish_details){
-        if (Array.isArray(asset.publish_details)) { 
-            publishedLocale = asset.publish_details[0].locale;
-        } else {
-            publishedLocale = asset.publish_details.locale;
-        }
-    }
+    let publishedLocale = asset.publish_details.locale;
     return createNodeId(`contentstack-assets-${asset.uid}-${publishedLocale}`);
 };
 
 const makeEntryNodeUid = exports.makeEntryNodeUid = (entry, createNodeId) => {
-    let publishedLocale = null;
-    if(entry && entry.publish_details){
-        if (Array.isArray(entry.publish_details)) { 
-            publishedLocale = entry.publish_details[0].locale;
-        } else {
-            publishedLocale = entry.publish_details.locale;
-        }
-    }
+    let publishedLocale = entry.publish_details.locale;
     return createNodeId(`contentstack-entry-${entry.uid}-${publishedLocale}`);
 };
 


### PR DESCRIPTION
Nodes were being created for the wrong locale because while `makeEntryNodeUid` was using the correct `entry.publish_details.locale` value,  `normalizeEntry` was using `entry.locale`.

Fixes:
- Use locale from publish details when creating nodes, not the origin locale.
- Removed dead code from makeAssetNodeUid and makeEntryNodeUid functions.