### PR TITLE
Added support for specifying a custom prefix for generated GraphQL types

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ plugins: [
       environment: `environment`,
 
       //CDN set this to point to other cdn end point. For eg: https://eu-cdn.contentstack.com/v3 . This is not required.
-      cdn: `cdn_url`
+      cdn: `cdn_url`,
+
+      // Optional: Specify a different prefix for types. This can be useful when using multiple instance of the plugin to connect to different stacks.
+      // type_prefix: `Contentstack`, // (default)
     },
   },
 ]


### PR DESCRIPTION
This change was made in order to support configuring multiple stacks within the same gatsby instance. It's fully backwards compatible.

E.g.:
```javascript
// In your gatsby-config.js
plugins: [
  {
    resolve: `gatsby-source-contentstack`,
    options: {
      api_key: `api_key1`,
      delivery_token: `deliver_token1`,
      environment: `environment1`,
      // defaults to "Contentstack" prefix
    },
  },
  {
    resolve: `gatsby-source-contentstack`,
    options: {
      api_key: `api_key2`,
      delivery_token: `deliver_token2`,
      environment: `environment2`,
      type_prefix: `Contentstack2`,
    },
  },
]
```