### PR TITLE
Generate a common schema type for global fields

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -322,7 +322,8 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, par
         break;
       case 'group':
       case 'global_field':
-        var newparent = parent.concat('_', field.uid);
+        var newparent = field.data_type === 'global_field' && field.reference_to ? prefix + '_' + field.reference_to : parent.concat('_', field.uid);
+
         var result = buildCustomSchema(field.schema, types, newparent, prefix);
         for (var key in result.fields) {
           if (Object.prototype.hasOwnProperty.call(result.fields[key], 'type')) {

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -297,7 +297,10 @@ const buildCustomSchema = exports.buildCustomSchema = (schema, types, parent, pr
         break;
       case 'group':
       case 'global_field':
-        const newparent = parent.concat('_', field.uid);
+        const newparent = field.data_type === 'global_field' && field.reference_to
+          ? `${prefix}_${field.reference_to}`
+          : parent.concat('_', field.uid);
+
         const result = buildCustomSchema(field.schema, types, newparent, prefix);
         for (const key in result.fields) {
           if (Object.prototype.hasOwnProperty.call(result.fields[key], 'type')) {


### PR DESCRIPTION
### Description
Previously a global field would generate a new type definition on each content type, e.g. `Contentstack__my_first_type_my_global_field` and `Contentstack__my_second_type_my_global_field`. However we know (by virtue of being a global field) that these will always be identical, so we could commonise these as a single type `Contentstack__my_global_field`.

### Motivation
I want to use GraphQL fragments to commonise my queries of global fields, this change means that I can define a fragment like:
```
fragment MyGlobalField on Contentstack_my_global_field {
  foo
  bar
}
```
and use it in queries for all content types using it:
```
query {
  Contentstack_my_first_type {
    my_global_field {
      ..MyGlobalField
    }
  }
}

query {
  Contentstack_my_second_type {
    my_global_field {
      ..MyGlobalField
    }
  }
}
```
which is a big saving for complex global fields which are used in lots of different content types.

N.B. This is potentially breaking if people are relying on the type names in queries (e.g. for fragments)