### PR TITLE
even mandatory number fields can have 0 as a valid value

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -258,13 +258,7 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, par
             return source[field.uid] || null;
           }
         };
-        if (field.mandatory) {
-          if (field.multiple) {
-            fields[field.uid].type = '[Int]!';
-          } else {
-            fields[field.uid].type = 'Int!';
-          }
-        } else if (field.multiple) {
+        if (field.multiple) {
           fields[field.uid].type = '[Int]';
         } else {
           fields[field.uid].type = 'Int';


### PR DESCRIPTION
We have a mandatory number field in our Content Type that accepts a number in the range [0,max]. When the value of that field is 0, we get GraphQl errors because the schema is generated as non-nullable:

> ERROR #85925  GRAPHQL
> 
> There was an error in your GraphQL query:
> 
> Cannot return null for non-nullable field Contentstack_material.maximum_amount_orderable.
> 
> The field "Contentstack_material.maximum_amount_orderable." was explicitly defined as non-nullable via the schema customization API (by yourself or a plugin/theme). This means that this field is not optional and you have to define a value. If this is not your desired behavior and you defined the schema yourself, go to "createTypes" in gatsby-node.js. If you're using a plugin/theme, you can learn more here on how to fix field types:
> https://www.gatsbyjs.org/docs/schema-customization/#fixing-field-types

This PR changes the generated schema for number fields to nullable, even for mandatory number fields.