### PR TITLE
Task/add more default typedefs

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -254,6 +254,18 @@ exports.extendSchemaWithDefaultEntryFields = function (schema) {
     multiple: false,
     mandatory: false
   });
+  schema.push({
+    data_type: 'isodate',
+    uid: 'created_at',
+    multiple: false,
+    mandatory: false
+  });
+  schema.push({
+    data_type: 'string',
+    uid: 'created_by',
+    multiple: false,
+    mandatory: false
+  });
   return schema;
 };
 

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -435,6 +435,18 @@ exports.extendSchemaWithDefaultEntryFields = schema => {
     multiple: false,
     mandatory: false,
   });
+  schema.push({
+    data_type: 'isodate',
+    uid: 'created_at',
+    multiple: false,
+    mandatory: false,
+  });
+  schema.push({
+    data_type: 'string',
+    uid: 'created_by',
+    multiple: false,
+    mandatory: false,
+  });
   return schema;
 };
 


### PR DESCRIPTION
Making sure that contentTypes with no entries have the created_at and created_by fields, which are default fields for entries.

This is required to not break queries against empty stacks / content types without entries