### PR TITLE
Task/configure mandatory fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ plugins: [
       // Optional: Specify true if you want to generate custom schema
       enableSchemaGeneration : `boolean_value`,
 
+      // Optional: Specify true if you want to generate optional graphQl fields for mandatory ContentStack fields
+      disableMandatoryFields : `boolean_value`,
+
       // Optional: Specify a different prefix for types. This is useful in cases where you have multiple instances of the plugin to be connected to different stacks.
       type_prefix: `Contentstack`, // (default)
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -61,33 +61,34 @@ exports.createSchemaCustomization = function () {
     var cache = _ref3.cache,
         actions = _ref3.actions,
         schema = _ref3.schema;
-    var contentTypes, typePrefix, createTypes, name, fields;
+    var contentTypes, typePrefix, disableMandatoryFields, createTypes, name, fields;
     return _regenerator2.default.wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
             contentTypes = void 0;
             typePrefix = configOptions.type_prefix || 'Contentstack';
-            _context.prev = 2;
-            _context.next = 5;
+            disableMandatoryFields = configOptions.disableMandatoryFields || false;
+            _context.prev = 3;
+            _context.next = 6;
             return fetchContentTypes(configOptions);
 
-          case 5:
+          case 6:
             contentTypes = _context.sent;
-            _context.next = 8;
+            _context.next = 9;
             return cache.set(typePrefix, contentTypes);
 
-          case 8:
-            _context.next = 13;
+          case 9:
+            _context.next = 14;
             break;
 
-          case 10:
-            _context.prev = 10;
-            _context.t0 = _context['catch'](2);
+          case 11:
+            _context.prev = 11;
+            _context.t0 = _context['catch'](3);
 
             console.error('Contentstack fetch content type failed!');
 
-          case 13:
+          case 14:
             if (configOptions.enableSchemaGeneration) {
               createTypes = actions.createTypes;
 
@@ -95,7 +96,7 @@ exports.createSchemaCustomization = function () {
                 var contentTypeUid = contentType.uid.replace(/-/g, '_');
                 var name = typePrefix + '_' + contentTypeUid;
                 var extendedSchema = extendSchemaWithDefaultEntryFields(contentType.schema);
-                var result = buildCustomSchema(extendedSchema, [], [], [], [], name, typePrefix);
+                var result = buildCustomSchema(extendedSchema, [], [], [], [], name, typePrefix, disableMandatoryFields);
                 references = references.concat(result.references);
                 groups = groups.concat(result.groups);
                 fileFields = fileFields.concat(result.fileFields);
@@ -128,12 +129,12 @@ exports.createSchemaCustomization = function () {
               })]);
             }
 
-          case 14:
+          case 15:
           case 'end':
             return _context.stop();
         }
       }
-    }, _callee, undefined, [[2, 10]]);
+    }, _callee, undefined, [[3, 11]]);
   }));
 
   return function (_x, _x2) {

--- a/normalize.js
+++ b/normalize.js
@@ -254,6 +254,18 @@ exports.extendSchemaWithDefaultEntryFields = function (schema) {
     multiple: false,
     mandatory: false
   });
+  schema.push({
+    data_type: 'isodate',
+    uid: 'created_at',
+    multiple: false,
+    mandatory: false
+  });
+  schema.push({
+    data_type: 'string',
+    uid: 'created_by',
+    multiple: false,
+    mandatory: false
+  });
   return schema;
 };
 

--- a/normalize.js
+++ b/normalize.js
@@ -451,7 +451,7 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, ref
         var unionType = 'union ';
         if (typeof field.reference_to === 'string' || field.reference_to.length === 1) {
           field.reference_to = Array.isArray(field.reference_to) ? field.reference_to[0] : field.reference_to;
-          var _type2 = 'type ' + prefix + '_' + field.reference_to + ' implements Node @infer { title: String! }';
+          var _type2 = 'type ' + prefix + '_' + field.reference_to + ' implements Node @infer { title: String' + (disableMandatoryFields ? '' : '!') + ' }';
           types.push(_type2);
 
           references.push({
@@ -470,7 +470,7 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, ref
             var referenceType = prefix + '_' + reference;
             unionType = unionType.concat(referenceType);
             unions.push(referenceType);
-            var type = 'type ' + referenceType + ' implements Node @infer { title: String! }';
+            var type = 'type ' + referenceType + ' implements Node @infer { title: String' + (disableMandatoryFields ? '' : '!') + ' }';
             types.push(type);
           });
           var name = '';

--- a/normalize.js
+++ b/normalize.js
@@ -191,7 +191,7 @@ var builtEntry = function builtEntry(schema, entry, locale, entriesNodeIds, asse
   return entryObj;
 };
 
-var buildBlockCustomSchema = function buildBlockCustomSchema(blocks, types, references, groups, fileFields, parent, prefix) {
+var buildBlockCustomSchema = function buildBlockCustomSchema(blocks, types, references, groups, fileFields, parent, prefix, disableMandatoryFields) {
   var blockFields = {};
   var blockType = 'type ' + parent + ' @infer {';
 
@@ -199,7 +199,7 @@ var buildBlockCustomSchema = function buildBlockCustomSchema(blocks, types, refe
     var newparent = parent.concat(block.uid);
     blockType = blockType.concat(block.uid + ' : ' + newparent + ' ');
 
-    var _buildCustomSchema = buildCustomSchema(block.schema, types, references, groups, fileFields, newparent, prefix),
+    var _buildCustomSchema = buildCustomSchema(block.schema, types, references, groups, fileFields, newparent, prefix, disableMandatoryFields),
         fields = _buildCustomSchema.fields;
 
     for (var key in fields) {
@@ -269,7 +269,7 @@ exports.extendSchemaWithDefaultEntryFields = function (schema) {
   return schema;
 };
 
-var buildCustomSchema = exports.buildCustomSchema = function (schema, types, references, groups, fileFields, parent, prefix) {
+var buildCustomSchema = exports.buildCustomSchema = function (schema, types, references, groups, fileFields, parent, prefix, disableMandatoryFields) {
   var fields = {};
   groups = groups || [];
   references = references || [];
@@ -283,7 +283,7 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, ref
             return source[field.uid] || null;
           }
         };
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid].type = '[String]!';
           } else {
@@ -296,7 +296,7 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, ref
         }
         break;
       case 'isodate':
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid] = '[Date]!';
           } else {
@@ -309,7 +309,7 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, ref
         }
         break;
       case 'boolean':
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid] = '[Boolean]!';
           } else {
@@ -327,7 +327,7 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, ref
             return source[field.uid] || null;
           }
         };
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid].type = '[Int]!';
           } else {
@@ -346,7 +346,7 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, ref
             return source[field.uid] || null;
           }
         };
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid].type = '[JSON]!';
           } else {
@@ -359,7 +359,7 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, ref
         }
         break;
       case 'link':
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid] = '[linktype]!';
           } else {
@@ -379,7 +379,7 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, ref
           field: field
         });
 
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid] = '[' + prefix + '_assets]!';
           } else {
@@ -395,7 +395,7 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, ref
       case 'global_field':
         var newparent = parent.concat('_', field.uid);
 
-        var result = buildCustomSchema(field.schema, types, references, groups, fileFields, newparent, prefix);
+        var result = buildCustomSchema(field.schema, types, references, groups, fileFields, newparent, prefix, disableMandatoryFields);
 
         for (var key in result.fields) {
           if (Object.prototype.hasOwnProperty.call(result.fields[key], 'type')) {
@@ -414,7 +414,7 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, ref
             field: field
           });
 
-          if (field.mandatory) {
+          if (field.mandatory && !disableMandatoryFields) {
             if (field.multiple) {
               fields[field.uid] = '[' + newparent + ']!';
             } else {
@@ -431,10 +431,10 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, ref
       case 'blocks':
         var blockparent = parent.concat('_', field.uid);
 
-        var blockType = buildBlockCustomSchema(field.blocks, types, references, groups, fileFields, blockparent, prefix);
+        var blockType = buildBlockCustomSchema(field.blocks, types, references, groups, fileFields, blockparent, prefix, disableMandatoryFields);
 
         types.push(blockType);
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid] = '[' + blockparent + ']!';
           } else {
@@ -459,7 +459,7 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, ref
             uid: field.uid
           });
 
-          if (field.mandatory) {
+          if (field.mandatory && !disableMandatoryFields) {
             fields[field.uid] = '[' + prefix + '_' + field.reference_to + ']!';
           } else {
             fields[field.uid] = '[' + prefix + '_' + field.reference_to + ']';
@@ -483,7 +483,7 @@ var buildCustomSchema = exports.buildCustomSchema = function (schema, types, ref
             uid: field.uid
           });
 
-          if (field.mandatory) {
+          if (field.mandatory && !disableMandatoryFields) {
             fields[field.uid] = '[' + name + ']!';
           } else {
             fields[field.uid] = '[' + name + ']';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-contentstack",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Gatsby source plugin for building websites using Contentstack as a data source",
   "scripts": {
     "prepublish": "npm run build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-contentstack",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Gatsby source plugin for building websites using Contentstack as a data source",
   "scripts": {
     "prepublish": "npm run build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-contentstack",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Gatsby source plugin for building websites using Contentstack as a data source",
   "scripts": {
     "prepublish": "npm run build",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -34,6 +34,7 @@ exports.createSchemaCustomization = async ({
   let contentTypes;
 
   const typePrefix = configOptions.type_prefix || 'Contentstack';
+  const disableMandatoryFields = configOptions.disableMandatoryFields || false;
   try {
     contentTypes = await fetchContentTypes(configOptions);
     await cache.set(typePrefix, contentTypes);
@@ -55,7 +56,8 @@ exports.createSchemaCustomization = async ({
         [],
         [],
         name,
-        typePrefix
+        typePrefix,
+        disableMandatoryFields
       );
       references = references.concat(result.references);
       groups = groups.concat(result.groups);

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -435,6 +435,18 @@ exports.extendSchemaWithDefaultEntryFields = schema => {
     multiple: false,
     mandatory: false,
   });
+  schema.push({
+    data_type: 'isodate',
+    uid: 'created_at',
+    multiple: false,
+    mandatory: false,
+  });
+  schema.push({
+    data_type: 'string',
+    uid: 'created_by',
+    multiple: false,
+    mandatory: false,
+  });
   return schema;
 };
 

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -659,7 +659,7 @@ const buildCustomSchema = (exports.buildCustomSchema = (
         let unionType = 'union ';
         if (typeof field.reference_to === 'string' || field.reference_to.length === 1) {
           field.reference_to = Array.isArray(field.reference_to) ? field.reference_to[0] : field.reference_to;
-          const type = `type ${prefix}_${field.reference_to} implements Node @infer { title: String! }`;
+          const type = `type ${prefix}_${field.reference_to} implements Node @infer { title: String${disableMandatoryFields ? '' : '!'} }`;
           types.push(type);
 
           references.push({
@@ -678,7 +678,7 @@ const buildCustomSchema = (exports.buildCustomSchema = (
             const referenceType = `${prefix}_${reference}`;
             unionType = unionType.concat(referenceType);
             unions.push(referenceType);
-            const type = `type ${referenceType} implements Node @infer { title: String! }`;
+            const type = `type ${referenceType} implements Node @infer { title: String${disableMandatoryFields ? '' : '!'} }`;
             types.push(type);
           });
           let name = '';

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -365,7 +365,8 @@ const buildBlockCustomSchema = (
   groups,
   fileFields,
   parent,
-  prefix
+  prefix,
+  disableMandatoryFields
 ) => {
   const blockFields = {};
   let blockType = `type ${parent} @infer {`;
@@ -380,7 +381,8 @@ const buildBlockCustomSchema = (
       groups,
       fileFields,
       newparent,
-      prefix
+      prefix,
+      disableMandatoryFields
     );
 
     for (const key in fields) {
@@ -459,7 +461,8 @@ const buildCustomSchema = (exports.buildCustomSchema = (
   groups,
   fileFields,
   parent,
-  prefix
+  prefix,
+  disableMandatoryFields
 ) => {
   const fields = {};
   groups = groups || [];
@@ -472,7 +475,7 @@ const buildCustomSchema = (exports.buildCustomSchema = (
         fields[field.uid] = {
           resolve: source => source[field.uid] || null,
         };
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid].type = '[String]!';
           } else {
@@ -485,7 +488,7 @@ const buildCustomSchema = (exports.buildCustomSchema = (
         }
         break;
       case 'isodate':
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid] = '[Date]!';
           } else {
@@ -498,7 +501,7 @@ const buildCustomSchema = (exports.buildCustomSchema = (
         }
         break;
       case 'boolean':
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid] = '[Boolean]!';
           } else {
@@ -514,7 +517,7 @@ const buildCustomSchema = (exports.buildCustomSchema = (
         fields[field.uid] = {
           resolve: source => source[field.uid] || null,
         };
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid].type = '[Int]!';
           } else {
@@ -531,7 +534,7 @@ const buildCustomSchema = (exports.buildCustomSchema = (
         fields[field.uid] = {
           resolve: source => source[field.uid] || null
         };
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid].type = '[JSON]!';
           } else {
@@ -544,7 +547,7 @@ const buildCustomSchema = (exports.buildCustomSchema = (
         }
         break;
       case 'link':
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid] = '[linktype]!';
           } else {
@@ -564,7 +567,7 @@ const buildCustomSchema = (exports.buildCustomSchema = (
           field
         })
         
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid] = `[${prefix}_assets]!`;
           } else {
@@ -587,7 +590,8 @@ const buildCustomSchema = (exports.buildCustomSchema = (
           groups,
           fileFields,
           newparent,
-          prefix
+          prefix,
+          disableMandatoryFields
         );
 
         for (const key in result.fields) {
@@ -609,7 +613,7 @@ const buildCustomSchema = (exports.buildCustomSchema = (
             field,
           });
 
-          if (field.mandatory) {
+          if (field.mandatory && !disableMandatoryFields) {
             if (field.multiple) {
               fields[field.uid] = `[${newparent}]!`;
             } else {
@@ -633,11 +637,12 @@ const buildCustomSchema = (exports.buildCustomSchema = (
           groups,
           fileFields,
           blockparent,
-          prefix
+          prefix,
+          disableMandatoryFields
         );
 
         types.push(blockType);
-        if (field.mandatory) {
+        if (field.mandatory && !disableMandatoryFields) {
           if (field.multiple) {
             fields[field.uid] = `[${blockparent}]!`;
           } else {
@@ -662,7 +667,7 @@ const buildCustomSchema = (exports.buildCustomSchema = (
             uid: field.uid,
           });
 
-          if (field.mandatory) {
+          if (field.mandatory && !disableMandatoryFields) {
             fields[field.uid] = `[${prefix}_${field.reference_to}]!`;
           } else {
             fields[field.uid] = `[${prefix}_${field.reference_to}]`;
@@ -686,7 +691,7 @@ const buildCustomSchema = (exports.buildCustomSchema = (
             uid: field.uid,
           });
 
-          if (field.mandatory) {
+          if (field.mandatory && !disableMandatoryFields) {
             fields[field.uid] = `[${name}]!`;
           } else {
             fields[field.uid] = `[${name}]`;


### PR DESCRIPTION
Since we have found many ways in which mandatory fields in ContentStack can end up being empty during a gatsby build, we prefer to have an option to not break the build when null is returned from a resolver for a mandatory field in CS.

Ways to have empty mandatory fields include:

1. Having mandatory references which are not published because only direct references are published automatically, but not indirect ones
2. Having not published all locales
3. Adding mandatory fields to content types with existing entries