### PR TITLE
Fixes the GraphQL warnings shown in CS-10058

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -24,6 +24,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var _require = require('./normalize'),
     normalizeEntry = _require.normalizeEntry,
+    sanitizeEntry = _require.sanitizeEntry,
     processContentType = _require.processContentType,
     processEntry = _require.processEntry,
     processAsset = _require.processAsset,
@@ -297,7 +298,8 @@ exports.sourceNodes = function () {
                 return item.content_type_uid === contentType.uid;
               });
               var normalizedEntry = normalizeEntry(contentType, item.data, entriesNodeIds, assetsNodeIds, createNodeId, typePrefix);
-              var entryNode = processEntry(contentType, normalizedEntry, createNodeId, createContentDigest, typePrefix);
+              var sanitizedEntry = sanitizeEntry(contentType.schema, normalizedEntry);
+              var entryNode = processEntry(contentType, sanitizedEntry, createNodeId, createContentDigest, typePrefix);
               createNode(entryNode);
             });
 

--- a/normalize.js
+++ b/normalize.js
@@ -83,7 +83,6 @@ exports.sanitizeEntry = function (schema, entry) {
 
 exports.normalizeEntry = function (contentType, entry, entriesNodeIds, assetsNodeIds, createNodeId, typePrefix) {
   var resolveEntry = (0, _extends3.default)({}, entry, builtEntry(contentType.schema, entry, entry.publish_details.locale, entriesNodeIds, assetsNodeIds, createNodeId, typePrefix));
-  resolveEntry.locale = entry.publish_details.locale;
   return resolveEntry;
 };
 

--- a/normalize.js
+++ b/normalize.js
@@ -69,6 +69,18 @@ exports.processEntry = function (contentType, entry, createNodeId, createContent
   return nodeData;
 };
 
+exports.sanitizeEntry = function (schema, entry) {
+  // Field data types that has ___NODE prefix to field.uid needs sanitization
+  var typesToBeSanitized = ['reference', 'file'];
+  schema.forEach(function (field) {
+    if (typesToBeSanitized.includes(field.data_type)) {
+      // Deleting entry[field.uid] because entry[`${field.uid}___NODE`] already exists
+      delete entry[field.uid];
+    }
+  });
+  return entry;
+};
+
 exports.normalizeEntry = function (contentType, entry, entriesNodeIds, assetsNodeIds, createNodeId, typePrefix) {
   var resolveEntry = (0, _extends3.default)({}, entry, builtEntry(contentType.schema, entry, entry.publish_details.locale, entriesNodeIds, assetsNodeIds, createNodeId, typePrefix));
   resolveEntry.locale = entry.publish_details.locale;

--- a/normalize.js
+++ b/normalize.js
@@ -71,6 +71,7 @@ exports.processEntry = function (contentType, entry, createNodeId, createContent
 
 exports.normalizeEntry = function (contentType, entry, entriesNodeIds, assetsNodeIds, createNodeId, typePrefix) {
   var resolveEntry = (0, _extends3.default)({}, entry, builtEntry(contentType.schema, entry, entry.publish_details.locale, entriesNodeIds, assetsNodeIds, createNodeId, typePrefix));
+  resolveEntry.locale = entry.publish_details.locale;
   return resolveEntry;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-contentstack",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Gatsby source plugin for building websites using Contentstack as a data source",
   "scripts": {
     "prepublish": "npm run build",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,5 +1,6 @@
 const {
   normalizeEntry,
+  sanitizeEntry,
   processContentType,
   processEntry,
   processAsset,
@@ -239,9 +240,10 @@ exports.sourceNodes = async ({
         createNodeId,
         typePrefix
       );
+      const sanitizedEntry = sanitizeEntry(contentType.schema, normalizedEntry);
       const entryNode = processEntry(
         contentType,
-        normalizedEntry,
+        sanitizedEntry,
         createNodeId,
         createContentDigest,
         typePrefix

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -102,7 +102,6 @@ exports.normalizeEntry = (
       typePrefix
     ),
   };
-  resolveEntry.locale = entry.publish_details.locale;
   return resolveEntry;
 };
 

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -70,6 +70,18 @@ exports.processEntry = (
   return nodeData;
 };
 
+exports.sanitizeEntry = (schema, entry) => {
+  // Field data types that has ___NODE prefix to field.uid needs sanitization
+  const typesToBeSanitized = ['reference', 'file'];
+  schema.forEach(field => {
+    if (typesToBeSanitized.includes(field.data_type)) {
+      // Deleting entry[field.uid] because entry[`${field.uid}___NODE`] already exists
+      delete entry[field.uid];
+    }
+  })
+  return entry;
+}
+
 exports.normalizeEntry = (
   contentType,
   entry,

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -90,6 +90,7 @@ exports.normalizeEntry = (
       typePrefix
     ),
   };
+  resolveEntry.locale = entry.publish_details.locale;
   return resolveEntry;
 };
 


### PR DESCRIPTION
Changes will fix the following warnings:
warning Multiple node fields resolve to the same GraphQL field `Contentstack_author.profile` - [`profile`, `profile___NODE`]. Gatsby
will use `profile___NODE`.

warning Multiple node fields resolve to the same GraphQL field `Contentstack_home.banner` - [`banner`, `banner___NODE`]. Gatsby will 
use `banner___NODE`.

warning Multiple node fields resolve to the same GraphQL field `Contentstack_blog_posts.author` - [`author`, `author__NODE`]. Gatsby will use `author__NODE`.

The warnings were thrown due to duplication of the property while creating custom schema for referenceFields and fileFields.
referenceFields and fileFields have a ___NODE suffix (eg: author___NODE) to their property names to remove the ambiguity but the actual fields were still present in the node which was causing two fields in the node (eg: author and author___NODE), hence the warnings were shown and the nodes needed to be sanitized before creating.
