### PR TITLE
fix(schema-customization): reference field dependency tracking for inc builds

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -393,17 +393,19 @@ exports.createResolvers = function (_ref7) {
       resolve: function resolve(source, args, context, info) {
         if (fileField.field.multiple && source[fileField.field.uid + '___NODE']) {
           var nodesData = [];
+
           source[fileField.field.uid + '___NODE'].forEach(function (id) {
-            context.nodeModel.getAllNodes().find(function (node) {
-              if (node.id === id) {
-                nodesData.push(node);
-              }
-            });
+            var existingNode = context.nodeModel.getNodeById({ id: id });
+
+            if (existingNode) {
+              nodesData.push(existingNode);
+            }
           });
+
           return nodesData;
         } else {
-          return context.nodeModel.getAllNodes().find(function (node) {
-            return node.id === source[fileField.field.uid + '___NODE'];
+          return context.nodeModel.getNodeById({
+            id: source[fileField.field.uid + '___NODE']
           });
         }
       }
@@ -414,13 +416,17 @@ exports.createResolvers = function (_ref7) {
       resolve: function resolve(source, args, context, info) {
         if (source[reference.uid + '___NODE']) {
           var nodesData = [];
+
           source[reference.uid + '___NODE'].forEach(function (id) {
-            context.nodeModel.getAllNodes().find(function (node) {
-              if (node.id === id) {
-                nodesData.push(node);
-              }
+            var existingNode = context.nodeModel.getNodeById({
+              id: id
             });
+
+            if (existingNode) {
+              nodesData.push(existingNode);
+            }
           });
+
           return nodesData;
         }
         return [];
@@ -440,8 +446,8 @@ exports.createResolvers = function (_ref7) {
   createResolvers(resolvers);
 };
 
-exports.pluginOptionsSchema = function (_ref7) {
-  var Joi = _ref7.Joi;
+exports.pluginOptionsSchema = function (_ref8) {
+  var Joi = _ref8.Joi;
 
   return Joi.object({
     api_key: Joi.string().required().description('API Key is a unique key assigned to each stack.'),
@@ -455,7 +461,7 @@ exports.pluginOptionsSchema = function (_ref7) {
 };
 
 var validateContentstackAccess = function () {
-  var _ref8 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee3(pluginOptions) {
+  var _ref9 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee3(pluginOptions) {
     var host;
     return _regenerator2.default.wrap(function _callee3$(_context3) {
       while (1) {
@@ -494,6 +500,6 @@ var validateContentstackAccess = function () {
   }));
 
   return function validateContentstackAccess(_x5) {
-    return _ref8.apply(this, arguments);
+    return _ref9.apply(this, arguments);
   };
 }();

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -404,9 +404,8 @@ exports.createResolvers = function (_ref7) {
 
           return nodesData;
         } else {
-          return context.nodeModel.getNodeById({
-            id: source[fileField.field.uid + '___NODE']
-          });
+          var id = source[fileField.field.uid + '___NODE'];
+          return context.nodeModel.getNodeById({ id: id });
         }
       }
     }));

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -361,9 +361,8 @@ exports.createResolvers = ({ createResolvers }) => {
 
               return nodesData;
             } else { 
-              return context.nodeModel.getNodeById({
-                id: source[`${fileField.field.uid}___NODE`]
-              })
+              const id = source[`${fileField.field.uid}___NODE`]
+              return context.nodeModel.getNodeById({ id })
             }
         },
       },

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -350,17 +350,20 @@ exports.createResolvers = ({ createResolvers }) => {
         resolve(source, args, context, info) {
           if (fileField.field.multiple && source[`${fileField.field.uid}___NODE`]) {
               const nodesData = [];
+              
               source[`${fileField.field.uid}___NODE`].forEach(id => {
-                context.nodeModel.getAllNodes().find(node => {
-                  if (node.id === id) {
-                    nodesData.push(node);
-                  }
-                });
+                const existingNode = context.nodeModel.getNodeById({ id })
+                
+                if (existingNode) {
+                  nodesData.push(existingNode);
+                }
               });
+
               return nodesData;
             } else { 
-              return context.nodeModel.getAllNodes().find(
-                node => node.id === source[`${fileField.field.uid}___NODE`])
+              return context.nodeModel.getNodeById({
+                id: source[`${fileField.field.uid}___NODE`]
+              })
             }
         },
       },
@@ -374,13 +377,17 @@ exports.createResolvers = ({ createResolvers }) => {
         resolve(source, args, context, info) {
           if (source[`${reference.uid}___NODE`]) {
             const nodesData = [];
+
             source[`${reference.uid}___NODE`].forEach(id => {
-              context.nodeModel.getAllNodes().find(node => {
-                if (node.id === id) {
-                  nodesData.push(node);
-                }
-              });
+              const existingNode = context.nodeModel.getNodeById({
+                id 
+              })
+              
+              if (existingNode) {
+                nodesData.push(existingNode);
+              }
             });
+
             return nodesData;
           }
           return [];


### PR DESCRIPTION
Hi there! 👋 
I work on the GatsbyJS integrations team. We recently had a mutual customer of yours/ours contact us about an incremental builds caching issue where data in reference fields wasn't updating without clearing the cache. This PR solves that :)

The issue is `getAllNodes()` in resolvers doesn't track resolved node dependencies in Gatsby v2 (we now do this in Gatsby V3). Using `getNodeById()` causes both Gatsby v2 and v3 to track query dependencies to properly re-run queries for reference fields - so this is a backwards/forwards compatible fix. As a nice side effect this is a much more scaleable way for these resolvers to behave. The previous logic was looping over all nodes that exist for every reference field on every node, now we specifically ask for referenced node's by id instead and don't need to iterate on all nodes.