### PR TITLE
Fix sizeBar initialization guard

### DIFF
--- a/src/download-assets.js
+++ b/src/download-assets.js
@@ -96,7 +96,7 @@ module.exports = async ({
 const createRemoteFileNodePromise = async (params, node, typePrefix, reporter) => {
   try {
 
-    if (totalSize === 0) {
+    if (!sizeBar) {
       sizeBar = createProgress(`Total KBs downloaded`, reporter);
       sizeBar.start();
     }


### PR DESCRIPTION
I occasionally see this creating multiple progresses because totalSize is still 0.