### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Mark the following as generated to avoid rendering them in reviews
+# We only want to review support files and those in src/*.js
+
+download-assets.js linguist-generated=true
+fetch.js linguist-generated=true
+gatsby-node.js linguist-generated=true
+normalize.js linguist-generated=true
+utils.js linguist-generated=true


### PR DESCRIPTION
This should help remove the built files from reviews to allow developers to focus on the changes.
Ideally we could just build files during release to keep the repo clean, but that's another topic.