### PR TITLE
Replace console timer with reporter activity

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -28,8 +28,9 @@ const OPTIONS_ENTRIES_CLASS_MAPPING = {
 };
 
 exports.fetchData = async (configOptions, reporter, cache, contentTypeOption) => {
-  console.time('Fetch Contentstack data');
-  console.log('Starting to fetch data from Contentstack');
+  const activity = reporter.activityTimer(`Fetch Contentstack data`)
+  activity.start()
+  activity.setStatus(`Starting to fetch data from Contentstack`)
 
   try {
     let syncData = {};
@@ -37,9 +38,9 @@ exports.fetchData = async (configOptions, reporter, cache, contentTypeOption) =>
     const _syncData = await entryService.fetchSyncData(configOptions, cache, fetchSyncData);
     syncData.data = _syncData.data;
     const contentstackData = { syncData: syncData.data };
-  
-    console.timeEnd('Fetch Contentstack data');
-  
+
+    activity.end()
+
     return { contentstackData };
   } catch (error) {
     reporter.panic({


### PR DESCRIPTION
This replaces the custom timer done via console.time with reporter.activity.
This helps ensure the output is flushed correctly in CI environments and keeps the log messages in order..