### PR TITLE
fix: Fix missing space in block interface generation

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -224,7 +224,7 @@ var buildBlockCustomSchema = function buildBlockCustomSchema(blocks, types, refe
 
     var newInterfaceParent = block.reference_to ? "".concat(prefix, "_").concat(block.reference_to) : interfaceParent && interfaceParent.concat(block.uid);
     blockType = blockType.concat("".concat(block.uid, " : ").concat(newparent, " "));
-    blockInterface = blockInterface && blockInterface.concat("".concat(block.uid, " : ").concat(newInterfaceParent));
+    blockInterface = blockInterface && blockInterface.concat("".concat(block.uid, " : ").concat(newInterfaceParent, " "));
 
     var _buildCustomSchema = buildCustomSchema(block.schema, types, references, groups, fileFields, jsonRteFields, newparent, prefix, disableMandatoryFields, jsonRteToHtml, createNodeId, newInterfaceParent),
         fields = _buildCustomSchema.fields;

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -197,7 +197,7 @@ const buildBlockCustomSchema = (blocks, types, references, groups, fileFields, j
     const newInterfaceParent = block.reference_to ? `${prefix}_${block.reference_to}` : interfaceParent && interfaceParent.concat(block.uid);
 
     blockType = blockType.concat(`${block.uid} : ${newparent} `);
-    blockInterface = blockInterface && blockInterface.concat(`${block.uid} : ${newInterfaceParent}`);
+    blockInterface = blockInterface && blockInterface.concat(`${block.uid} : ${newInterfaceParent} `);
 
     const { fields } = buildCustomSchema(block.schema, types, references, groups, fileFields, jsonRteFields, newparent, prefix, disableMandatoryFields, jsonRteToHtml, createNodeId, newInterfaceParent);
 


### PR DESCRIPTION
It looks like #164 has a bug caused by a missing space - which I think will break the custom schema generation for anybody with certain types of nested modular blocks.

This should be a very small fix, to make the interface generation logic match the type generation logic.