### PR TITLE
Fix/mkt 2696 clone adding custom limit parameter for gatsby build

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ plugins: [
       // Optional: Specify a number to perform http-retries for network failures. By default it is set to 3.
       httpRetries: 2,
 
-      //Specify the limit. Maximum limit accepted is 100.
+      //Specify the number of entries/assets to be fetched per page. Maximum limit accepted is 100.
       limit: 50
     },
   },

--- a/README.md
+++ b/README.md
@@ -4,14 +4,11 @@ Contentstack provides a source plugin for pulling content into [Gatsby][gatsby] 
 
 Here’s an example site built using this source plugin: https://xenodochial-hodgkin-8a267e.netlify.com/
 
-
-
 ##### **NOTE**
 
- >- Use Node v18+ and React v18+ while using v5.x.x of gatsby-source-contentstack.
- >- Please refer migration guide: [Migrating from v4 to v5](https://v5.gatsbyjs.com/docs/reference/release-notes/migrating-from-v4-to-v5/)
- >- Added support for subsequent fetch calls when data is being published during ongoing init calls or build process.
-
+> - Use Node v18+ and React v18+ while using v5.x.x of gatsby-source-contentstack.
+> - Please refer migration guide: [Migrating from v4 to v5](https://v5.gatsbyjs.com/docs/reference/release-notes/migrating-from-v4-to-v5/)
+> - Added support for subsequent fetch calls when data is being published during ongoing init calls or build process.
 
 ## Install
 
@@ -30,16 +27,16 @@ plugins: [
       // Required: API Key is a unique key assigned to each stack.
       api_key: `api_key`,
 
-      // Required: Delivery Token is a read-only credential. 
+      // Required: Delivery Token is a read-only credential.
       delivery_token: `delivery_token`,
-      
+
       // Required: Environment where you published your data.
       environment: `environment`,
 
       // Optional: Specify branch name. Default it would fetch from "main".
       branch: `branch name`,
 
-      // Optional: CDN set this to point to other cdn end point. For eg: https://eu-cdn.contentstack.com/v3 
+      // Optional: CDN set this to point to other cdn end point. For eg: https://eu-cdn.contentstack.com/v3
       cdn: `cdn_url`,
 
       // Recommended: Specify true if you want to fetch/source data parallelly. It enhances the performance on both gatsby build/develop command.
@@ -71,22 +68,24 @@ plugins: [
 
       // Optional: Specify true to convert the JSON-RTE repsonse to HTML. Default it is set to false
       jsonRteToHtml: false ,
-      
+
       // Optional: Specify a number to perform http-retries for network failures. By default it is set to 3.
-      httpRetries: 2
+      httpRetries: 2,
+
+      //Specify the limit. Maximum limit accepted is 100.
+      limit: 50
     },
   },
 ]
 // Note: access_token is replaced by delivery_token
 ```
-There is a provision to speed up the ```gatsby build``` process. To do this, you can set the value of the **expediteBuild** to **true**. So when you set the value of this parameter to true, the build process is significantly enhanced as only published assets and entries are synced parallelly. 
+There is a provision to speed up the `gatsby build` process. To do this, you can set the value of the **expediteBuild** to **true**. So when you set the value of this parameter to true, the build process is significantly enhanced as only published assets and entries are synced parallelly.
 
-However, when you want to perform ```gatsby develop```, ensure to set the value of **expediteBuild** to **false**.
+However, when you want to perform `gatsby develop`, ensure to set the value of **expediteBuild** to **false**.
 
 ## How to query
 
-You can query nodes created from Contentstack using GraphQL. 
-
+You can query nodes created from Contentstack using GraphQL.
 
 All content types and the corresponding entries are pulled from your stack. They'll be created in your site's GraphQL schema under `contentstack${contentTypeID}` and `allContentstack${contentTypeID}`.
 
@@ -97,7 +96,6 @@ GraphQL model.
 ## Querying entries
 
 If, for example, you have `Blogs` as one of your content types, you will be able to query its entries in the following manner:
-
 
 ```graphql
 {
@@ -138,14 +136,14 @@ referred entry are often needed, the referred entry data is provided at the `ref
 
 ```graphql
 {
-  allContentstackBlogs{
+  allContentstackBlogs {
     edges {
       node {
         id
         title
         url
         description
-        authors{
+        authors {
           name
         }
         created_at
@@ -244,11 +242,11 @@ To use this, you need to have the following plugins installed:
 
 Next step is to add an image to your page query and use the gatsbyImageData resolver to pass arguments that will configure your image.
 
-The gatsbyImageData resolver allows you to pass arguments to format and configure your images. 
+The gatsbyImageData resolver allows you to pass arguments to format and configure your images.
 Using the Contentstack Image delivery APIs you can perform various operations on the images by passing the necessary parameters.
 
 Lets understand this with an example.
-In the below example we have added several parameters to format the image. 
+In the below example we have added several parameters to format the image.
 
 ```graphql
 {
@@ -261,7 +259,7 @@ In the below example we have added several parameters to format the image.
             layout: CONSTRAINED
             crop: "100,100"
             trim: "25,25,100,100"
-            backgroundColor:"cccccc"
+            backgroundColor: "cccccc"
             pad: "25,25,25,25"
           )
         }
@@ -273,7 +271,7 @@ In the below example we have added several parameters to format the image.
 
 Lets understand some parameters that we defined:
 layout: This defines the layout of the image, it can be CONSTRAINED, FIXED or FULL_WIDTH.
-The crop, trim, backgroundColor and pad parameters configure the image according to the values inserted by the user. 
+The crop, trim, backgroundColor and pad parameters configure the image according to the values inserted by the user.
 
 Note: To learn more about these parameters and other available options, read our detailed documentation on [Contentstack Image delivery APIs](https://www.contentstack.com/docs/developers/apis/image-delivery-api/).
 
@@ -281,6 +279,7 @@ This query below returns the URL for a 20px-wide image, to use as a blurred plac
 The image is downloaded and converted to a base64-encoded data URI.
 
 Here’s an example of the same:
+
 ```graphql
 {
   allContentstackBlog {
@@ -293,7 +292,7 @@ Here’s an example of the same:
             placeholder: BLURRED
             crop: "100,100"
             trim: "25,25,100,100"
-            backgroundColor:"cccccc"
+            backgroundColor: "cccccc"
             pad: "25,25,25,25"
           )
         }
@@ -310,41 +309,43 @@ Since version 5.1, a class - `ContentstackGatsby` is provided which facilitates 
 Initialize `ContentstackGatsby` and live preview SDK.
 
 ```jsx
-import { ContentstackGatsby } from "gatsby-source-contentstack/live-preview";
-import ContentstackLivePreview from "@contentstack/live-preview-utils";
+import { ContentstackGatsby } from 'gatsby-source-contentstack/live-preview';
+import ContentstackLivePreview from '@contentstack/live-preview-utils';
 
 export const getCSData = new ContentstackGatsby({
-    api_key: GATSBY_CONTENTSTACK_API_KEY,
-    environment: GATSBY_CONTENTSTACK_ENVIRONMENT,
-    live_preview: {
-        management_token: GATSBY_CONTENTSTACK_MANAGEMENT_TOKEN,
-        enable: true,
-        host: "api.contentstack.io" // "eu-api.contentstack.com" for EU region
-    }
+  api_key: GATSBY_CONTENTSTACK_API_KEY,
+  environment: GATSBY_CONTENTSTACK_ENVIRONMENT,
+  live_preview: {
+    management_token: GATSBY_CONTENTSTACK_MANAGEMENT_TOKEN,
+    enable: true,
+    host: 'api.contentstack.io', // "eu-api.contentstack.com" for EU region
+  },
 });
 
 ContentstackLivePreview.init({
-    stackSdk: getCSData.stackSdk,
+  stackSdk: getCSData.stackSdk,
 });
 ```
+
 Next, in a page/component, pass a function to `ContentstackLivePreview`'s `onEntryChange()` or `onLiveEdit()` method. This function should call ContentstackGatsby.get() with the initial data as a parameter.
 
-
 ```jsx
-const Home = (props) => {
-  const [data, setData] = useState(props.data.allContentstackPage.nodes[0])
+const Home = props => {
+  const [data, setData] = useState(props.data.allContentstackPage.nodes[0]);
 
   const fetchLivePreviewData = async () => {
-    const updatedData = await getCSData.get(props.data.allContentstackPage.nodes[0]);
-    setData(updatedData)
-  }
+    const updatedData = await getCSData.get(
+      props.data.allContentstackPage.nodes[0]
+    );
+    setData(updatedData);
+  };
 
   useEffect(() => {
-    ContentstackLivePreview.onLiveEdit(fetchLivePreviewData)
-  }, [])
+    ContentstackLivePreview.onLiveEdit(fetchLivePreviewData);
+  }, []);
 
-  return <div>{data.title}</div>
-}
+  return <div>{data.title}</div>;
+};
 ```
 
 For more information on using live preview, please refer to [Set up Live Preview](https://www.contentstack.com/docs/developers/sample-apps/build-a-starter-website-with-gatsby-and-contentstack#set-up-live-preview-optional) for Gatsby sites.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ plugins: [
       // Optional: Specify a number to perform http-retries for network failures. By default it is set to 3.
       httpRetries: 2,
 
-      //Specify the number of entries/assets to be fetched per page. Maximum limit accepted is 100.
+      //Specify the number of entries/assets to be fetched per page. Maximum limit accepted is 100. By default it is set to 50.
       limit: 50
     },
   },

--- a/fetch.js
+++ b/fetch.js
@@ -275,7 +275,7 @@ var getPagedData = /*#__PURE__*/function () {
   var _ref7 = (0, _asyncToGenerator2["default"])(function (url, config, responseKey) {
     var query = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
     var skip = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : 0;
-    var limit = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : 100;
+    var limit = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : (config === null || config === void 0 ? void 0 : config.limit) || 50;
     var aggregatedResponse = arguments.length > 6 && arguments[6] !== undefined ? arguments[6] : null;
     return /*#__PURE__*/_regenerator["default"].mark(function _callee7() {
       var response;
@@ -283,7 +283,8 @@ var getPagedData = /*#__PURE__*/function () {
         while (1) switch (_context7.prev = _context7.next) {
           case 0:
             query.skip = skip;
-            query.limit = limit;
+            //if limit is greater than 100, it will throw ann error that limit cannot exceed 100.
+            query.limit = limit > 100 ? (console.error('Limit cannot exceed 100.'), 100) : limit;
             query.include_global_field_schema = true;
             _context7.next = 5;
             return fetchCsData(url, config, query);

--- a/fetch.js
+++ b/fetch.js
@@ -275,7 +275,7 @@ var getPagedData = /*#__PURE__*/function () {
   var _ref7 = (0, _asyncToGenerator2["default"])(function (url, config, responseKey) {
     var query = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
     var skip = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : 0;
-    var limit = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : (config === null || config === void 0 ? void 0 : config.limit) || 50;
+    var limit = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : config === null || config === void 0 ? void 0 : config.limit;
     var aggregatedResponse = arguments.length > 6 && arguments[6] !== undefined ? arguments[6] : null;
     return /*#__PURE__*/_regenerator["default"].mark(function _callee7() {
       var response;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatsby-source-contentstack",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gatsby-source-contentstack",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
         "@contentstack/utils": "^1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatsby-source-contentstack",
-  "version": "5.2.0",
+  "version": "5.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gatsby-source-contentstack",
-      "version": "5.2.0",
+      "version": "5.1.1",
       "license": "MIT",
       "dependencies": {
         "@contentstack/utils": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-contentstack",
-  "version": "5.2.0",
+  "version": "5.1.1",
   "description": "Gatsby source plugin for building websites using Contentstack as a data source",
   "scripts": {
     "prepublish": "npm run build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-contentstack",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Gatsby source plugin for building websites using Contentstack as a data source",
   "scripts": {
     "prepublish": "npm run build",

--- a/plugin-options-schema.js
+++ b/plugin-options-schema.js
@@ -19,7 +19,8 @@ exports.pluginOptionsSchema = function (_ref) {
     excludeContentTypes: Joi.array().items(Joi.string().required()).description("Specify list of content-types to be excluded while fetching data from contentstack"),
     locales: Joi.array().items(Joi.string().required()).description("Specify list of locales to be fetched from contentstack"),
     jsonRteToHtml: Joi["boolean"]()["default"](false).description("Specify true if you want to generate html from json RTE field"),
-    httpRetries: Joi.number().integer()["default"](3).description("Specify the number of times to perform http request on a network failure")
+    httpRetries: Joi.number().integer()["default"](3).description("Specify the number of times to perform http request on a network failure"),
+    limit: Joi.number().integer()["default"](50).description("Specify the number of entries/assets to be fetched per page")
   }).external(validateContentstackAccess);
 };
 //# sourceMappingURL=plugin-options-schema.js.map

--- a/src/entry-data.js
+++ b/src/entry-data.js
@@ -18,10 +18,10 @@ class FetchDefaultEntries extends FetchEntries {
         
         const syncEntryParams = syncEntryToken
           ? { sync_token: syncEntryToken }
-          : { init: true, limit: configOptions.limit > 100 ? 100 : configOptions.limit };
+          : { init: true, limit: configOptions.limit > 50 ? 100 : configOptions.limit };
         const syncAssetParams = syncAssetToken
           ? { sync_token: syncAssetToken }
-          : { init: true, limit: configOptions.limit > 100 ? 100 : configOptions.limit };
+          : { init: true, limit: configOptions.limit > 50 ? 100 : configOptions.limit };
 
         syncEntryParams.type = 'entry_published,entry_unpublished,entry_deleted';
         syncAssetParams.type = 'asset_published,asset_unpublished,asset_deleted';
@@ -34,7 +34,7 @@ class FetchDefaultEntries extends FetchEntries {
         const syncToken = await cache.get(tokenKey);
         const syncParams = syncToken
           ? { sync_token: syncToken }
-          : { init: true, limit: configOptions.limit > 100 ? 100 : configOptions.limit };
+          : { init: true, limit: configOptions.limit > 50 ? 100 : configOptions.limit };
 
         syncData = await fn.apply(null, [syncParams, configOptions]);
         // Caching token for the next sync

--- a/src/entry-data.js
+++ b/src/entry-data.js
@@ -18,10 +18,10 @@ class FetchDefaultEntries extends FetchEntries {
         
         const syncEntryParams = syncEntryToken
           ? { sync_token: syncEntryToken }
-          : { init: true, limit: configOptions.limit };
+          : { init: true, limit: configOptions.limit > 100 ? 100 : configOptions.limit };
         const syncAssetParams = syncAssetToken
           ? { sync_token: syncAssetToken }
-          : { init: true, limit: configOptions.limit };
+          : { init: true, limit: configOptions.limit > 100 ? 100 : configOptions.limit };
 
         syncEntryParams.type = 'entry_published,entry_unpublished,entry_deleted';
         syncAssetParams.type = 'asset_published,asset_unpublished,asset_deleted';
@@ -34,7 +34,7 @@ class FetchDefaultEntries extends FetchEntries {
         const syncToken = await cache.get(tokenKey);
         const syncParams = syncToken
           ? { sync_token: syncToken }
-          : { init: true, limit: configOptions.limit };
+          : { init: true, limit: configOptions.limit > 100 ? 100 : configOptions.limit };
 
         syncData = await fn.apply(null, [syncParams, configOptions]);
         // Caching token for the next sync

--- a/src/entry-data.js
+++ b/src/entry-data.js
@@ -15,8 +15,13 @@ class FetchDefaultEntries extends FetchEntries {
         const assetTokenKey = `${typePrefix.toLowerCase()}-sync-token-asset-${configOptions.api_key}`;
         const [syncEntryToken, syncAssetToken] = await Promise.all([cache.get(entryTokenKey), cache.get(assetTokenKey)])
 
-        const syncEntryParams = syncEntryToken ? { sync_token: syncEntryToken } : { init: true };
-        const syncAssetParams = syncAssetToken ? { sync_token: syncAssetToken } : { init: true };
+        
+        const syncEntryParams = syncEntryToken
+          ? { sync_token: syncEntryToken }
+          : { init: true, limit: configOptions.limit };
+        const syncAssetParams = syncAssetToken
+          ? { sync_token: syncAssetToken }
+          : { init: true, limit: configOptions.limit };
 
         syncEntryParams.type = 'entry_published,entry_unpublished,entry_deleted';
         syncAssetParams.type = 'asset_published,asset_unpublished,asset_deleted';
@@ -27,7 +32,9 @@ class FetchDefaultEntries extends FetchEntries {
       } else {
         const tokenKey = `${typePrefix.toLowerCase()}-sync-token-${configOptions.api_key}`;
         const syncToken = await cache.get(tokenKey);
-        const syncParams = syncToken ? { sync_token: syncToken } : { init: true };
+        const syncParams = syncToken
+          ? { sync_token: syncToken }
+          : { init: true, limit: configOptions.limit };
 
         syncData = await fn.apply(null, [syncParams, configOptions]);
         // Caching token for the next sync

--- a/src/entry-data.js
+++ b/src/entry-data.js
@@ -18,10 +18,10 @@ class FetchDefaultEntries extends FetchEntries {
         
         const syncEntryParams = syncEntryToken
           ? { sync_token: syncEntryToken }
-          : { init: true, limit: configOptions.limit > 50 ? 100 : configOptions.limit };
+          : { init: true, limit: configOptions.limit > 100 ? 50 : configOptions.limit };
         const syncAssetParams = syncAssetToken
           ? { sync_token: syncAssetToken }
-          : { init: true, limit: configOptions.limit > 50 ? 100 : configOptions.limit };
+          : { init: true, limit: configOptions.limit > 100 ? 50 : configOptions.limit };
 
         syncEntryParams.type = 'entry_published,entry_unpublished,entry_deleted';
         syncAssetParams.type = 'asset_published,asset_unpublished,asset_deleted';
@@ -34,7 +34,7 @@ class FetchDefaultEntries extends FetchEntries {
         const syncToken = await cache.get(tokenKey);
         const syncParams = syncToken
           ? { sync_token: syncToken }
-          : { init: true, limit: configOptions.limit > 50 ? 100 : configOptions.limit };
+          : { init: true, limit: configOptions.limit > 100 ? 50 : configOptions.limit };
 
         syncData = await fn.apply(null, [syncParams, configOptions]);
         // Caching token for the next sync

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -52,7 +52,6 @@ let globalConfig;
 
 const syncToken = [];
 
-
 exports.fetchData = async (
   configOptions,
   reporter,
@@ -193,11 +192,13 @@ const getPagedData = async (
   responseKey,
   query = {},
   skip = 0,
-  limit = 100,
+  limit = config?.limit || 50,
   aggregatedResponse = null
 ) => {
   query.skip = skip;
-  query.limit = limit;
+  //if limit is greater than 100, it will throw ann error that limit cannot exceed 100.
+  query.limit =
+    limit >= 100 ? (console.error('Limit cannot exceed 100.'), 100) : limit;
   query.include_global_field_schema = true;
   const response = await fetchCsData(url, config, query);
   if (!aggregatedResponse) {

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -197,8 +197,10 @@ const getPagedData = async (
 ) => {
   query.skip = skip;
   //if limit is greater than 100, it will throw ann error that limit cannot exceed 100.
-  query.limit =
-    limit > 100 ? (console.error('Limit cannot exceed 100.'), 100) : limit;
+  if (limit > 100) {
+    console.error('Limit cannot exceed 100. Setting limit to 50.');
+  }
+  query.limit = limit > 100 ? 50 : limit;
   query.include_global_field_schema = true;
   const response = await fetchCsData(url, config, query);
   if (!aggregatedResponse) {

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -198,7 +198,7 @@ const getPagedData = async (
   query.skip = skip;
   //if limit is greater than 100, it will throw ann error that limit cannot exceed 100.
   query.limit =
-    limit >= 100 ? (console.error('Limit cannot exceed 100.'), 100) : limit;
+    limit > 100 ? (console.error('Limit cannot exceed 100.'), 100) : limit;
   query.include_global_field_schema = true;
   const response = await fetchCsData(url, config, query);
   if (!aggregatedResponse) {

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -192,7 +192,7 @@ const getPagedData = async (
   responseKey,
   query = {},
   skip = 0,
-  limit = config?.limit || 50,
+  limit = config?.limit,
   aggregatedResponse = null
 ) => {
   query.skip = skip;

--- a/src/plugin-options-schema.js
+++ b/src/plugin-options-schema.js
@@ -19,5 +19,6 @@ exports.pluginOptionsSchema = ({ Joi }) => {
     locales: Joi.array().items(Joi.string().required()).description(`Specify list of locales to be fetched from contentstack`),
     jsonRteToHtml: Joi.boolean().default(false).description(`Specify true if you want to generate html from json RTE field`),
     httpRetries: Joi.number().integer().default(3).description(`Specify the number of times to perform http request on a network failure`),
+    limit: Joi.number().integer().default(50).description(`Specify the number of entries/assets to be fetched per page`),
   }).external(validateContentstackAccess);
 };


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18CrxcBY4m4XSdXa3HthJev6HRNS0NI6JA%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=k_r3l3q)


- Added the support to make limit value {No. of entries to be fetched at a time} configurable. 