### PR TITLE
fix: reinitialize sync token array to empty after sub-sync calls

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -50,7 +50,7 @@ const OPTIONS_ENTRIES_CLASS_MAPPING = {
 let activity;
 let globalConfig;
 
-const syncToken = [];
+let syncToken = [];
 
 exports.fetchData = async (
   configOptions,
@@ -288,5 +288,6 @@ const getSyncData = async (
     }
   }
 
+  syncToken = []
   return aggregatedResponse;
 };


### PR DESCRIPTION
ISSUE https://contentstack.atlassian.net/browse/MKT-3002