### PR TITLE
feat: determine LP reference and RTE paths during query resolution

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Contentstack
+Copyright (c) 2024 Contentstack
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "contentstack": "^3.17.1",
         "gatsby-core-utils": "^3.23.0",
         "gatsby-source-filesystem": "^5.7.0",
+        "lodash.clonedeep": "^4.5.0",
         "lodash.isempty": "^4.4.0",
         "node-fetch": "^2.6.9",
         "progress": "^2.0.3",
@@ -10224,6 +10225,11 @@
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
       "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
       "dev": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -23837,6 +23843,11 @@
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
       "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
       "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "contentstack": "^3.17.1",
     "gatsby-core-utils": "^3.23.0",
     "gatsby-source-filesystem": "^5.7.0",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.isempty": "^4.4.0",
     "node-fetch": "^2.6.9",
     "progress": "^2.0.3",

--- a/src/live-preview/getCslpMetaPaths.js
+++ b/src/live-preview/getCslpMetaPaths.js
@@ -1,0 +1,120 @@
+export function getCslpMetaPaths(
+  selectionSet,
+  path = "",
+  schema,
+  fragments,
+  contentTypeMap,
+  typePrefix
+) {
+  const paths = {
+    referencePaths: [],
+    jsonRtePaths: [],
+  }
+  const refPaths = paths.referencePaths;
+  const rtePaths = paths.jsonRtePaths;
+  if (schema.data_type === "reference" && path) {
+    refPaths.push(path)
+  }
+  if (schema.data_type === "json" && schema.field_metadata?.allow_json_rte) {
+    rtePaths.push(path)
+  }
+  if (!selectionSet || !selectionSet.selections) {
+    return paths;
+  }
+  for (const selection of selectionSet.selections) {
+    // exit when selection.kind is not Field, SelectionSet or InlineFragment
+    // selection.name is not present for selection.kind is "InlineFragment"
+    if (selection?.name?.value === "cslp__meta") {
+      continue;
+    }
+    if (
+      selection.selectionSet ||
+      selection.kind === "Field" ||
+      selection.kind === "InlineFragment" ||
+      selection.kind === "FragmentSpread"
+    ) {
+
+      const fragmentName = selection.name?.value;
+      const fragmentDefinition = fragments[fragmentName];
+      const inlineFragmentNodeType = selection.typeCondition?.name?.value;
+
+      // Fragment
+      // note - when a fragment is used inside a reference field, the reference field
+      // path gets added twice, this can maybe avoided by re-structuring the code, 
+      // but a Set works fine
+      if (selection.kind === "FragmentSpread" && fragmentDefinition) {
+        const fragmentSpreadPaths = getCslpMetaPaths(
+          fragmentDefinition.selectionSet,
+          path,
+          schema,
+          fragments,
+          contentTypeMap,
+          typePrefix
+        );
+        combineCslpMetaPaths(fragmentSpreadPaths, paths)
+      }
+      // InlineFragment (ref_multiple)
+      else if (selection.kind === "InlineFragment" && inlineFragmentNodeType) {
+        const contentTypeUid = inlineFragmentNodeType.replace(`${typePrefix}_`, "");
+        if (!contentTypeUid || !(contentTypeUid in contentTypeMap)) {
+          return paths;
+        }
+        const contentTypeSchema = contentTypeMap[contentTypeUid];
+        const inlineFragmentPaths = getCslpMetaPaths(
+          selection.selectionSet,
+          path,
+          contentTypeSchema,
+          fragments,
+          contentTypeMap,
+          typePrefix
+        );
+        combineCslpMetaPaths(inlineFragmentPaths, paths)
+      }
+      // SelectionSet (all fields that can have nested properties)
+      else {
+        let nestedFields = schema?.blocks ?? schema.schema;
+        // cannot traverse inside file or link schema
+        if (schema.data_type === "file" || schema.data_type === "link") {
+          return paths;
+        }
+        // when a reference, change nested fields to schema of referenced CT
+        if (schema.data_type === "reference" && schema.reference_to) {
+          nestedFields = contentTypeMap[schema.reference_to[0]].schema
+        }
+        const nestedFieldSchema = nestedFields.find((item) => item.uid === selection.name.value);
+        if (nestedFieldSchema) {
+          let nextPath = [];
+          if (path) {
+            nextPath = path.split(".");
+          }
+          nextPath.push(selection.name.value);
+          const metaPaths = getCslpMetaPaths(
+            selection.selectionSet,
+            nextPath.join("."),
+            nestedFieldSchema,
+            fragments,
+            contentTypeMap,
+            typePrefix
+          );
+          combineCslpMetaPaths(metaPaths, paths);
+        }
+      }
+    }
+  }
+  return {
+    referencePaths: Array.from(new Set(paths.referencePaths)),
+    jsonRtePaths: Array.from(new Set(paths.jsonRtePaths))
+  };
+}
+
+/**
+ * @typedef {{referencePaths: string[], jsonRtePaths: string[]}} paths
+ * @param {paths} source 
+ * @param {paths} target 
+ * @returns merges the path fields from the source into the target's path fields
+ */
+function combineCslpMetaPaths(source, target) {
+  target.referencePaths.push(...source.referencePaths);
+  target.jsonRtePaths.push(...source.jsonRtePaths);
+  return target;
+}

--- a/src/live-preview/index.js
+++ b/src/live-preview/index.js
@@ -114,7 +114,7 @@ export class ContentstackGatsby {
         return contentTypes;
       }
     } catch (error) {
-      console.error('ContentstackGatsby - Failed to fetch content types');
+      console.error("Contentstack Gatsby (Live Preview): failed to fetch content types");
       throw error;
     }
   }

--- a/src/live-preview/index.js
+++ b/src/live-preview/index.js
@@ -4,6 +4,9 @@ import isEmpty from "lodash.isempty";
 import cloneDeep from "lodash.clonedeep";
 import { Storage } from "./storage-helper";
 
+// max depth for nested references
+const MAX_DEPTH_ALLOWED = 5;
+
 export class ContentstackGatsby {
   config;
   stackSdk;
@@ -18,7 +21,7 @@ export class ContentstackGatsby {
       content_type_uid: "",
       entry_uid: ""
     }
-    
+
     const stackConfig = {
       api_key: config.api_key,
       delivery_token: config.delivery_token,
@@ -32,12 +35,259 @@ export class ContentstackGatsby {
       },
     }
     this.stackSdk = contentstack.Stack(stackConfig);
+    // reference fields in various CTs and the CTs they refer
+    this.referenceFieldsStorage = new Storage(
+      window.sessionStorage,
+      'reference_fields'
+    );
+    this.referenceFields = this.referenceFieldsStorage.get();
 
     this.statusStorage = new Storage(window.sessionStorage, "status")
+
+    // json rte fields in various CTs
+    this.jsonRteFieldsStorage = new Storage(
+      window.sessionStorage,
+      'json_rte_fields'
+    );
+    this.jsonRteFields = this.jsonRteFieldsStorage.get();
+
+    // only field paths extracted from the above map for current CT
+    this.referenceFieldPaths = [];
+
+    // store content types in LP site's session storage
+    this.contentTypesStorage = new Storage(
+      window.sessionStorage,
+      'content_types'
+    );
+    this.contentTypes = this.contentTypesStorage.get();
   }
 
   setHost(host) {
     this.stackSdk.setHost(host);
+  }
+
+  /**
+   * @deprecated With the `cslp__meta` query field, this should not be required
+   * @param {Object.<string, any>} entry 
+   */
+  static addContentTypeUidFromTypename(entry) {
+    if (typeof entry === "undefined") {
+      throw new TypeError("entry cannot be empty");
+    }
+    if (entry === null) {
+      throw new TypeError("entry cannot be null")
+    }
+    if (typeof entry !== "object") {
+      throw new TypeError("entry must be an object")
+    }
+    if (Array.isArray(entry)) {
+      throw new TypeError("entry cannot be an object, pass an instance of entry")
+    }
+
+    traverse(entry)
+
+    function traverse(field) {
+      if (!field || typeof field !== "object") {
+        return;
+      }
+      if (Array.isArray(field)) {
+        field.forEach((instance) => traverse(instance))
+      }
+      if (Object.hasOwnProperty.call(field, "__typename") && typeof field.__typename == "string") {
+        field._content_type_uid = field.__typename.split("_").slice(1).join("_");
+      }
+      Object.values(field).forEach((subField) => traverse(subField))
+    }
+  }
+
+  async fetchContentTypes(uids) {
+    try {
+      const result = await this.stackSdk.getContentTypes({
+        query: { uid: { $in: uids } },
+        include_global_field_schema: true,
+      });
+      if (result) {
+        const contentTypes = {};
+        result.content_types.forEach(ct => {
+          contentTypes[ct.uid] = ct;
+        });
+        return contentTypes;
+      }
+    } catch (error) {
+      console.error('ContentstackGatsby - Failed to fetch content types');
+      throw error;
+    }
+  }
+
+  async getContentTypes(uids) {
+    // fetch and filter only content types that are not available in cache
+    const uidsToFetch = uids.filter(uid => !this.contentTypes[uid]);
+    if (!uidsToFetch.length) {
+      return this.contentTypes;
+    }
+    const types = await this.fetchContentTypes(uidsToFetch);
+    uidsToFetch.forEach(uid => {
+      // TODO need to set it in two places, can be better
+      this.contentTypes[uid] = types[uid];
+      this.contentTypesStorage.set(uid, types[uid]);
+    });
+    return this.contentTypes;
+  }
+
+  async extractReferences(
+    refPathMap = {},
+    status,
+    jsonRtePaths = [],
+    depth = MAX_DEPTH_ALLOWED,
+    seen = []
+  ) {
+    if (depth <= 0) {
+      return refPathMap;
+    }
+    const uids = [...new Set(Object.values(refPathMap).flat())];
+    const contentTypes = await this.getContentTypes(uids);
+    const refPathsCount = Object.keys(refPathMap).length;
+    const explorePaths = Object.entries(refPathMap).filter(
+      ([path]) => !seen.includes(path)
+    );
+    for (const [refPath, refUids] of explorePaths) {
+      // mark this reference path as seen
+      seen.push(refPath);
+      for (const uid of refUids) {
+        let rPath = refPath.split('.');
+        // when path is root, set path to []
+        if (refPath === '') {
+          rPath = [];
+        }
+
+        if (!status.hasLivePreviewEntryFound) {
+          status.hasLivePreviewEntryFound = this.isCurrentEntryEdited(uid)
+        }
+
+        this.extractUids(
+          contentTypes[uid].schema,
+          rPath,
+          refPathMap,
+          jsonRtePaths
+        );
+      }
+    }
+    if (Object.keys(refPathMap).length > refPathsCount) {
+      await this.extractReferences(refPathMap, status, jsonRtePaths, depth - 1, seen);
+    }
+    return { refPathMap, jsonRtePaths };
+  }
+
+  extractUids(schema, pathPrefix = [], refPathMap = {}, jsonRtePaths = []) {
+    const referredUids = [];
+    for (const field of schema) {
+      const fieldPath = [...pathPrefix, field.uid];
+      if (
+        field.data_type === 'reference' &&
+        Array.isArray(field.reference_to) &&
+        field.reference_to.length > 0
+      ) {
+        referredUids.push(...field.reference_to);
+        refPathMap[fieldPath.join('.')] = field.reference_to;
+      } else if (
+        field.data_type === 'blocks' &&
+        field.blocks &&
+        field.blocks.length > 0
+      ) {
+        for (const block of field.blocks) {
+          const { referredUids: blockRefUids } = this.extractUids(
+            block.schema,
+            [...fieldPath, block.uid],
+            refPathMap,
+            jsonRtePaths
+          );
+          referredUids.push(...blockRefUids);
+        }
+      } else if (
+        field.data_type === 'group' &&
+        field.schema &&
+        field.schema.length > 0
+      ) {
+        const { referredUids: groupRefUids } = this.extractUids(
+          field.schema,
+          [...fieldPath],
+          refPathMap,
+          jsonRtePaths
+        );
+        referredUids.push(...groupRefUids);
+      } else if (
+        field.data_type === 'json' &&
+        field.field_metadata?.allow_json_rte
+      ) {
+        const rtePath = [...pathPrefix, field.uid].join('.');
+        jsonRtePaths.push(rtePath);
+      }
+    }
+    return { referredUids, refPathMap };
+  }
+
+  /**
+  * Identify reference paths in user-provided data
+  * @param {any} data - entry data
+  * @param {string[]} currentPath - traversal path
+  * @param {string[]} referenceFieldPaths - content type reference paths
+  */
+  identifyReferences(data, currentPath = [], referenceFieldPaths = []) {
+    const paths = [];
+
+    for (const [k, v] of Object.entries(data)) {
+      if (!v) {
+        continue;
+      }
+      if (currentPath.length > 0) {
+        const refPath = currentPath.join('.');
+        // if a reference path and not already collected, collect it
+        if (referenceFieldPaths.includes(refPath) && !paths.includes(refPath)) {
+          paths.push(refPath);
+        }
+      }
+      if (this.isNested(v)) {
+        const tempPath = [...currentPath];
+        tempPath.push(k);
+        const p = this.identifyReferences(v, tempPath, referenceFieldPaths);
+        paths.push(...p);
+      } else if (Array.isArray(v)) {
+        const tempPath = [...currentPath];
+        tempPath.push(k);
+        if (v.length > 0) {
+          // need to go over all refs since each of them could be of different
+          // content type and might contain refs
+          for (const val of v) {
+            const p = this.identifyReferences(
+              val,
+              tempPath,
+              referenceFieldPaths
+            );
+            paths.push(...p);
+          }
+        }
+        // no multiple ref present, Gatsby value -> [] (empty array)
+        // no single ref present, Gatsby value -> []
+        else if (
+          v.length === 0 &&
+          referenceFieldPaths.includes(tempPath.join('.'))
+        ) {
+          // it is a single or multiple ref
+          // also no idea what child references the user must be querying
+          // so need to get all child refs
+          paths.push(tempPath.join('.'));
+          const childRefPaths = referenceFieldPaths.filter(path =>
+            path.startsWith(tempPath)
+          );
+          paths.push(...childRefPaths);
+        }
+      }
+    }
+    return [...new Set(paths)];
+  }
+
+  isCurrentEntryEdited(entryContentType) {
+    return entryContentType === this.livePreviewConfig?.content_type_uid
   }
 
   async fetchEntry(entryUid, contentTypeUid, referencePaths = [], jsonRtePaths = []) {
@@ -77,7 +327,76 @@ export class ContentstackGatsby {
     return values;
   }
 
+  async getUsingTypeName(data) {
+    const receivedData = cloneDeep(data);
+    const { live_preview } = this.stackSdk;
+
+    let status = {
+      hasLivePreviewEntryFound: false
+    }
+
+    this.livePreviewConfig = live_preview;
+
+    const contentTypeUid = receivedData.__typename.split("_").slice(1).join("_")
+    const entryUid = receivedData.uid;
+
+    status = this.statusStorage.get(contentTypeUid) ?? { hasLivePreviewEntryFound: this.isCurrentEntryEdited(contentTypeUid) }
+
+    if (
+      isEmpty(this.referenceFields[contentTypeUid]) ||
+      isEmpty(this.jsonRteFields[contentTypeUid])
+    ) {
+      try {
+        const { refPathMap, jsonRtePaths } = await this.extractReferences({
+          '': [contentTypeUid],
+        }, status);
+        // store reference paths
+        this.referenceFields[contentTypeUid] = refPathMap;
+        this.referenceFieldsStorage.set(
+          contentTypeUid,
+          this.referenceFields[contentTypeUid]
+        );
+        // store json rte paths
+        this.jsonRteFields[contentTypeUid] = jsonRtePaths;
+        this.jsonRteFieldsStorage.set(
+          contentTypeUid,
+          this.jsonRteFields[contentTypeUid]
+        );
+      }
+      catch (error) {
+        console.error("Contentstack Gatsby (Live Preview): an error occurred while determining reference paths", error);
+        console.log("Contentstack Gatsby (Live Preview): unable to determine reference paths. This may have occurred due to the way the content types refer each other. Please try including the cslp__meta field in your query.");
+        return receivedData;
+      }
+    }
+
+    let referencePaths = Object.keys(this.referenceFields[contentTypeUid]);
+    referencePaths = referencePaths.filter(field => !!field)
+
+    const paths = this.identifyReferences(
+      receivedData,
+      [],
+      referencePaths
+    );
+
+    this.statusStorage.set(contentTypeUid, status)
+
+    if (!status.hasLivePreviewEntryFound) {
+      return receivedData
+    }
+
+    const entry = await this.fetchEntry(
+      entryUid,
+      contentTypeUid,
+      paths,
+      this.jsonRteFields[contentTypeUid] ?? []
+    );
+    return entry;
+  }
+
   async get(data) {
+    // if cslp__meta is found, use the paths from cslp__meta
+    // else use the old method to determine the paths
     if (data === null) {
       console.warn("Contentstack Gatsby (Live Preview): null was passed to get()");
       return data;
@@ -89,6 +408,9 @@ export class ContentstackGatsby {
     const dataCloned = cloneDeep(data);
     delete dataCloned["$"];
 
+    // old method metadata
+    const hasTypeNameAndUid = dataCloned.uid && dataCloned.__typename;
+    // new method metadata
     const hasCslpMetaAtRoot = dataCloned.cslp__meta;
     const multipleEntriesKey = Object.keys(dataCloned);
     const hasSingleEntry = !hasCslpMetaAtRoot && multipleEntriesKey.length === 1;
@@ -109,7 +431,7 @@ export class ContentstackGatsby {
         receivedData.length > 1 &&
         receivedData.every((item) => item === null || item.cslp__meta);
 
-      if (!hasCslpMeta && !hasMultipleCslpMeta) {
+      if (!hasCslpMeta && !hasMultipleCslpMeta && !hasTypeNameAndUid) {
         throw new Error("Contentstack Gatsby (Live Preview): Entry data must contain cslp__meta for live preview")
       }
 
@@ -137,20 +459,24 @@ export class ContentstackGatsby {
           return dataCloned;
         }
       }
+      else if (hasCslpMeta) {
+        const entryCslpMeta = receivedData.cslp__meta;
+        const contentTypeUid = entryCslpMeta.contentTypeUid;
+        const entryUid = entryCslpMeta.entryUid;
 
-      const entryCslpMeta = receivedData.cslp__meta;
-      const contentTypeUid = entryCslpMeta.contentTypeUid;
-      const entryUid = entryCslpMeta.entryUid;
+        if (!entryUid || !contentTypeUid) {
+          console.warn("Contentstack Gatsby (Live Preview): no entry uid or content type uid was found inside cslp__meta")
+          return dataCloned;
+        }
 
-      if (!entryUid || !contentTypeUid) {
-        console.warn("Contentstack Gatsby (Live Preview): no entry uid or content type uid was found inside cslp__meta")
-        return dataCloned;
+        const refPaths = entryCslpMeta.referencePaths ?? [];
+        const rtePaths = entryCslpMeta.jsonRtePaths ?? [];
+        const entry = await this.fetchEntry(entryUid, contentTypeUid, refPaths, rtePaths);
+        return entry;
       }
-
-      const refPaths = entryCslpMeta.referencePaths ?? [];
-      const rtePaths = entryCslpMeta.jsonRtePaths ?? [];
-      const entry = await this.fetchEntry(entryUid, contentTypeUid, refPaths, rtePaths);
-      return entry;
+      else if (hasTypeNameAndUid) {
+        return await this.getUsingTypeName(dataCloned);
+      }
     }
     return dataCloned;
   }

--- a/src/live-preview/index.js
+++ b/src/live-preview/index.js
@@ -87,7 +87,6 @@ export class ContentstackGatsby {
       return data;
     }
     const dataCloned = cloneDeep(data);
-    console.log(dataCloned)
     delete dataCloned["$"];
 
     const hasCslpMetaAtRoot = dataCloned.cslp__meta;
@@ -99,8 +98,6 @@ export class ContentstackGatsby {
       this.unwrapEntryData(dataCloned) :
       dataCloned;
     const { live_preview } = this.stackSdk;
-
-
 
     if (live_preview?.hash && live_preview.hash !== 'init') {
       this.livePreviewConfig = live_preview;

--- a/src/live-preview/index.js
+++ b/src/live-preview/index.js
@@ -397,6 +397,10 @@ export class ContentstackGatsby {
   async get(data) {
     // if cslp__meta is found, use the paths from cslp__meta
     // else use the old method to determine the paths
+    if (this.stackSdk.live_preview && !this.stackSdk.live_preview?.enable) {
+      console.warn("Contentstack Gatsby (Live Preview): live preview is disabled in config");
+      return data;
+    }
     if (data === null) {
       console.warn("Contentstack Gatsby (Live Preview): null was passed to get()");
       return data;

--- a/src/live-preview/index.js
+++ b/src/live-preview/index.js
@@ -1,10 +1,8 @@
-import contentstack from 'contentstack';
-import { jsonToHTML } from '@contentstack/utils';
-import isEmpty from 'lodash.isempty';
-import { Storage } from './storage-helper';
-
-// max depth for nested references
-const MAX_DEPTH_ALLOWED = 5;
+import contentstack from "contentstack";
+import { jsonToHTML } from "@contentstack/utils";
+import isEmpty from "lodash.isempty";
+import cloneDeep from "lodash.clonedeep";
+import { Storage } from "./storage-helper";
 
 export class ContentstackGatsby {
   config;
@@ -35,190 +33,30 @@ export class ContentstackGatsby {
     }
     this.stackSdk = contentstack.Stack(stackConfig);
 
-    // reference fields in various CTs and the CTs they refer
-    this.referenceFieldsStorage = new Storage(
-      window.sessionStorage,
-      'reference_fields'
-    );
-    this.referenceFields = this.referenceFieldsStorage.get();
-
     this.statusStorage = new Storage(window.sessionStorage, "status")
-
-    // json rte fields in various CTs
-    this.jsonRteFieldsStorage = new Storage(
-      window.sessionStorage,
-      'json_rte_fields'
-    );
-    this.jsonRteFields = this.jsonRteFieldsStorage.get();
-
-    // only field paths extracted from the above map for current CT
-    this.referenceFieldPaths = [];
-
-    // store content types in LP site's session storage
-    this.contentTypesStorage = new Storage(
-      window.sessionStorage,
-      'content_types'
-    );
-    this.contentTypes = this.contentTypesStorage.get();
   }
 
   setHost(host) {
     this.stackSdk.setHost(host);
   }
 
-  static addContentTypeUidFromTypename(entry) {
-    if (typeof entry === "undefined") {
-      throw new TypeError("entry cannot be empty");
-    }
-    if (entry === null) {
-      throw new TypeError("entry cannot be null")
-    }
-    if (typeof entry !== "object") {
-      throw new TypeError("entry must be an object")
-    }
-    if (Array.isArray(entry)) {
-      throw new TypeError("entry cannot be an object, pass an instance of entry")
-    }
+  async fetchEntry(entryUid, contentTypeUid, referencePaths = [], jsonRtePaths = []) {
+    const entry = await this.stackSdk
+      .ContentType(contentTypeUid)
+      .Entry(entryUid)
+      .includeReference(referencePaths)
+      .toJSON()
+      .fetch();
 
-    traverse(entry)
-
-    function traverse(field) {
-      if (!field || typeof field !== "object") {
-        return;
-      }
-      if (Array.isArray(field)) {
-        field.forEach((instance) => traverse(instance))
-      }
-      if (Object.hasOwnProperty.call(field, "__typename") && typeof field.__typename == "string") {
-        field._content_type_uid = field.__typename.split("_").slice(1).join("_");
-      }
-      Object.values(field).forEach((subField) => traverse(subField))
-    }
-  }
-
-  async fetchContentTypes(uids) {
-    try {
-      const result = await this.stackSdk.getContentTypes({
-        query: { uid: { $in: uids } },
-      });
-      if (result) {
-        const contentTypes = {};
-        result.content_types.forEach(ct => {
-          contentTypes[ct.uid] = ct;
+    if (!isEmpty(entry)) {
+      if (this.config.jsonRteToHtml) {
+        jsonToHTML({
+          entry: entry,
+          paths: jsonRtePaths,
         });
-        return contentTypes;
       }
-    } catch (error) {
-      console.error('ContentstackGatsby - Failed to fetch content types');
-      throw error;
+      return entry;
     }
-  }
-
-  async getContentTypes(uids) {
-    // fetch and filter only content types that are not available in cache
-    const uidsToFetch = uids.filter(uid => !this.contentTypes[uid]);
-    if (!uidsToFetch.length) {
-      return this.contentTypes;
-    }
-    const types = await this.fetchContentTypes(uidsToFetch);
-    uidsToFetch.forEach(uid => {
-      // TODO need to set it in two places, can be better
-      this.contentTypes[uid] = types[uid];
-      this.contentTypesStorage.set(uid, types[uid]);
-    });
-    return this.contentTypes;
-  }
-
-  async extractReferences(
-    refPathMap = {},
-    status,
-    jsonRtePaths = [],
-    depth = MAX_DEPTH_ALLOWED,
-    seen = []
-  ) {
-    if (depth <= 0) {
-      return refPathMap;
-    }
-    const uids = [...new Set(Object.values(refPathMap).flat())];
-    const contentTypes = await this.getContentTypes(uids);
-    const refPathsCount = Object.keys(refPathMap).length;
-    const explorePaths = Object.entries(refPathMap).filter(
-      ([path]) => !seen.includes(path)
-    );
-    for (const [refPath, refUids] of explorePaths) {
-      // mark this reference path as seen
-      seen.push(refPath);
-      for (const uid of refUids) {
-        let rPath = refPath.split('.');
-        // when path is root, set path to []
-        if (refPath === '') {
-          rPath = [];
-        }
-
-        if (!status.hasLivePreviewEntryFound) {
-          status.hasLivePreviewEntryFound = this.isCurrentEntryEdited(uid)
-        }
-
-        this.extractUids(
-          contentTypes[uid].schema,
-          rPath,
-          refPathMap,
-          jsonRtePaths
-        );
-      }
-    }
-    if (Object.keys(refPathMap).length > refPathsCount) {
-      await this.extractReferences(refPathMap, status, jsonRtePaths, depth - 1, seen);
-    }
-    return { refPathMap, jsonRtePaths };
-  }
-
-  extractUids(schema, pathPrefix = [], refPathMap = {}, jsonRtePaths = []) {
-    const referredUids = [];
-    for (const field of schema) {
-      const fieldPath = [...pathPrefix, field.uid];
-      if (
-        field.data_type === 'reference' &&
-        Array.isArray(field.reference_to) &&
-        field.reference_to.length > 0
-      ) {
-        referredUids.push(...field.reference_to);
-        refPathMap[fieldPath.join('.')] = field.reference_to;
-      } else if (
-        field.data_type === 'blocks' &&
-        field.blocks &&
-        field.blocks.length > 0
-      ) {
-        for (const block of field.blocks) {
-          const { referredUids: blockRefUids } = this.extractUids(
-            block.schema,
-            [...fieldPath, block.uid],
-            refPathMap,
-            jsonRtePaths
-          );
-          referredUids.push(...blockRefUids);
-        }
-      } else if (
-        field.data_type === 'group' &&
-        field.schema &&
-        field.schema.length > 0
-      ) {
-        const { referredUids: groupRefUids } = this.extractUids(
-          field.schema,
-          [...fieldPath],
-          refPathMap,
-          jsonRtePaths
-        );
-        referredUids.push(...groupRefUids);
-      } else if (
-        field.data_type === 'json' &&
-        field.field_metadata?.allow_json_rte
-      ) {
-        const rtePath = [...pathPrefix, field.uid].join('.');
-        jsonRtePaths.push(rtePath);
-      }
-    }
-    return { referredUids, refPathMap };
   }
 
   isNested(value) {
@@ -228,143 +66,95 @@ export class ContentstackGatsby {
     return false;
   }
 
-  /**
-   * Identify reference paths in user-provided data
-   * @param {any} data - entry data
-   * @param {string[]} currentPath - traversal path
-   * @param {string[]} referenceFieldPaths - content type reference paths
-   */
-  identifyReferences(data, currentPath = [], referenceFieldPaths = []) {
-    const paths = [];
-
-    for (const [k, v] of Object.entries(data)) {
-      if (!v) {
-        continue;
-      }
-      if (currentPath.length > 0) {
-        const refPath = currentPath.join('.');
-        // if a reference path and not already collected, collect it
-        if (referenceFieldPaths.includes(refPath) && !paths.includes(refPath)) {
-          paths.push(refPath);
-        }
-      }
-      if (this.isNested(v)) {
-        const tempPath = [...currentPath];
-        tempPath.push(k);
-        const p = this.identifyReferences(v, tempPath, referenceFieldPaths);
-        paths.push(...p);
-      } else if (Array.isArray(v)) {
-        const tempPath = [...currentPath];
-        tempPath.push(k);
-        if (v.length > 0) {
-          // need to go over all refs since each of them could be of different
-          // content type and might contain refs
-          for (const val of v) {
-            const p = this.identifyReferences(
-              val,
-              tempPath,
-              referenceFieldPaths
-            );
-            paths.push(...p);
-          }
-        }
-        // no multiple ref present, Gatsby value -> [] (empty array)
-        // no single ref present, Gatsby value -> []
-        else if (
-          v.length === 0 &&
-          referenceFieldPaths.includes(tempPath.join('.'))
-        ) {
-          // it is a single or multiple ref
-          // also no idea what child references the user must be querying
-          // so need to get all child refs
-          paths.push(tempPath.join('.'));
-          const childRefPaths = referenceFieldPaths.filter(path =>
-            path.startsWith(tempPath)
-          );
-          paths.push(...childRefPaths);
-        }
-      }
+  unwrapEntryData(data) {
+    const values = Object.values(data);
+    if (!values) {
+      return data;
     }
-    return [...new Set(paths)];
-  }
-
-  isCurrentEntryEdited(entryContentType) {
-    return entryContentType === this.livePreviewConfig?.content_type_uid
+    if (values && values.length === 1) {
+      return values[0];
+    }
+    return values;
   }
 
   async get(data) {
-    const receivedData = structuredClone(data);
+    if (data === null) {
+      console.warn("Contentstack Gatsby (Live Preview): null was passed to get()");
+      return data;
+    }
+    if (!this.isNested(data)) {
+      console.warn("Contentstack Gatsby (Live Preview): data passed to get() is invalid")
+      return data;
+    }
+    const dataCloned = cloneDeep(data);
+    console.log(dataCloned)
+    delete dataCloned["$"];
+
+    const hasCslpMetaAtRoot = dataCloned.cslp__meta;
+    const multipleEntriesKey = Object.keys(dataCloned);
+    const hasSingleEntry = !hasCslpMetaAtRoot && multipleEntriesKey.length === 1;
+    const hasMultipleEntries = !hasCslpMetaAtRoot && multipleEntriesKey.length > 1;
+
+    const receivedData = hasSingleEntry || hasMultipleEntries ?
+      this.unwrapEntryData(dataCloned) :
+      dataCloned;
     const { live_preview } = this.stackSdk;
 
-    let status = {
-      hasLivePreviewEntryFound: false
-    }
+
 
     if (live_preview?.hash && live_preview.hash !== 'init') {
       this.livePreviewConfig = live_preview;
-      if (!receivedData.__typename) {
-        throw new Error("Entry data must contain __typename for live preview")
-      }
-      if (!receivedData.uid) {
-        throw new Error("Entry data must contain uid for live preview")
-      }
-      const contentTypeUid = receivedData.__typename.split("_").slice(1).join("_")
-      const entryUid = receivedData.uid;
 
-      status = this.statusStorage.get(contentTypeUid) ?? { hasLivePreviewEntryFound: this.isCurrentEntryEdited(contentTypeUid) }
+      const hasCslpMeta = receivedData.cslp__meta;
 
-      if (
-        isEmpty(this.referenceFields[contentTypeUid]) ||
-        isEmpty(this.jsonRteFields[contentTypeUid])
-      ) {
-        const { refPathMap, jsonRtePaths } = await this.extractReferences({
-          '': [contentTypeUid],
-        }, status);
-        // store reference paths
-        this.referenceFields[contentTypeUid] = refPathMap;
-        this.referenceFieldsStorage.set(
-          contentTypeUid,
-          this.referenceFields[contentTypeUid]
-        );
-        // store json rte paths
-        this.jsonRteFields[contentTypeUid] = jsonRtePaths;
-        this.jsonRteFieldsStorage.set(
-          contentTypeUid,
-          this.jsonRteFields[contentTypeUid]
-        );
+      // item can be null, since gatsby can return null
+      const hasMultipleCslpMeta = Array.isArray(receivedData) &&
+        receivedData.length > 1 &&
+        receivedData.every((item) => item === null || item.cslp__meta);
+
+      if (!hasCslpMeta && !hasMultipleCslpMeta) {
+        throw new Error("Contentstack Gatsby (Live Preview): Entry data must contain cslp__meta for live preview")
       }
 
-      let referencePaths = Object.keys(this.referenceFields[contentTypeUid]);
-      referencePaths = referencePaths.filter(field => !!field)
-
-      const paths = this.identifyReferences(
-        receivedData,
-        [],
-        referencePaths
-      );
-
-      this.statusStorage.set(contentTypeUid, status)
-
-      if (!status.hasLivePreviewEntryFound) {
-        return receivedData
-      }
-
-      const entry = await this.stackSdk
-        .ContentType(contentTypeUid)
-        .Entry(entryUid)
-        .includeReference(paths)
-        .toJSON()
-        .fetch();
-      if (!isEmpty(entry)) {
-        if (this.config.jsonRteToHtml) {
-          jsonToHTML({
-            entry: entry,
-            paths: this.jsonRteFields[contentTypeUid] ?? [],
+      if (hasMultipleCslpMeta) {
+        try {
+          const multipleLPEntries = await Promise.all(receivedData.map((item) => {
+            if (item === null) {
+              return Promise.resolve(null)
+            }
+            return this.fetchEntry(
+              item.cslp__meta.entryUid,
+              item.cslp__meta.contentTypeUid,
+              item.cslp__meta.refPaths,
+              item.cslp__meta.rtePaths
+            )
+          }))
+          const result = {}
+          multipleEntriesKey.forEach((key, index) => {
+            result[key] = multipleLPEntries[index];
           });
+          return result;
         }
-        return entry;
+        catch (error) {
+          console.error("Contentstack Gatsby (Live Preview):", error);
+          return dataCloned;
+        }
       }
+
+      const entryCslpMeta = receivedData.cslp__meta;
+      const contentTypeUid = entryCslpMeta.contentTypeUid;
+      const entryUid = entryCslpMeta.entryUid;
+
+      if (!entryUid || !contentTypeUid) {
+        console.warn("Contentstack Gatsby (Live Preview): no entry uid or content type uid was found inside cslp__meta")
+        return dataCloned;
+      }
+
+      const refPaths = entryCslpMeta.referencePaths ?? [];
+      const rtePaths = entryCslpMeta.jsonRtePaths ?? [];
+      const entry = await this.fetchEntry(entryUid, contentTypeUid, refPaths, rtePaths);
+      return entry;
     }
-    return receivedData;
+    return dataCloned;
   }
 }

--- a/src/live-preview/resolveCslpMeta.js
+++ b/src/live-preview/resolveCslpMeta.js
@@ -1,0 +1,93 @@
+import { getCslpMetaPaths } from "./getCslpMetaPaths";
+
+export function resolveCslpMeta({
+  source,
+  args: _args,
+  context: _context,
+  info,
+  contentTypeMap,
+  typePrefix
+}) {
+  const entryUid = source.uid;
+  const contentTypeNodeType = source.internal.type
+  const queryContentTypeUid = contentTypeNodeType.replace(`${typePrefix}_`, "")
+
+  const fieldNode = info.fieldNodes.find((node) => node.name?.value === "cslp__meta");
+  const fieldNodeValue = "cslp__meta";
+  const fieldNodeLocation = { start: fieldNode.name?.loc?.start, end: fieldNode.name?.loc?.end }
+
+  // We have all the query selections (`info.operation.selectionSet.selections`) 
+  // each time we resolve cslp__meta.
+  // So, get the correct Selection from query for the current cslp__meta
+  const queryContentTypeSelection = findQuerySelection(
+    info.operation.selectionSet,
+    fieldNodeValue,
+    fieldNodeLocation
+  )
+
+  if (typeof queryContentTypeSelection === "undefined") {
+    return {
+      error: {
+        message: "failed to find query selection for cslp__meta"
+      }
+    }
+  }
+
+  const fragments = info?.fragments ?? {};
+  const contentType = contentTypeMap[queryContentTypeUid];
+  // for the content type selection, get the reference and json RTE paths
+  const metaPaths = getCslpMetaPaths(
+    queryContentTypeSelection,
+    "",
+    contentType,
+    fragments,
+    contentTypeMap,
+    typePrefix
+  )
+  const result = {
+    entryUid,
+    contentTypeUid: contentType.uid,
+    ...metaPaths,
+  }
+  return result;
+}
+
+function findQuerySelection(selectionSet, value, location, depth = 0) {
+  // cslp__meta can only be one level deep (or two level deep, see all* case below) 
+  // e.g.
+  // query {
+  //   page {
+  //     cslp__meta
+  //   }
+  //   allBlog {
+  //     nodes {
+  //       cslp__meta
+  //     }
+  //   }
+  // }
+  if (depth > 1 || !selectionSet || !selectionSet.selections) {
+    return;
+  }
+  for (const selection of selectionSet.selections) {
+    if (
+      selection.name?.value === value &&
+      selection.loc?.start === location.start &&
+      selection.loc?.end === location.end
+    ) {
+      return selectionSet
+    }
+    // "nodes" in all* queries will lead to cslp__meta at depth 2
+    if (selection.name?.value === "nodes") {
+      const nestedSelectionSet = findQuerySelection(selection.selectionSet, value, location, depth);
+      if (nestedSelectionSet) {
+        return nestedSelectionSet;
+      }
+    }
+    // search one level deeper for the correct node in this selection
+    const nestedSelectionSet = findQuerySelection(selection.selectionSet, value, location, depth + 1)
+    // return when not undefined, meaning the correct selection has been found
+    if (nestedSelectionSet) {
+      return nestedSelectionSet;
+    }
+  }
+}


### PR DESCRIPTION
As of 5.1.2, for **live preview**, we determine all possible reference paths and JSON RTE paths at runtime by fetching content types and recursively iterating over them. For very complex content types, this process results in a lot of reference paths caching which becomes impossible.

This change adds a new custom field `cslp__meta` to each content type node, which resolves with the value of reference paths and JSON RTE paths. This leads to a significant improvement in speed, as no expensive runtime calculation has to be done. 

To resolve `cslp__meta`, we iterate over the content types and the Gatsby query (using the `info` argument of the resolver - `info.operation`) and collect the reference and RTE paths.