### PR TITLE
fix: respect excludeContentTypes during entry sync in shared-stack se…

### DIFF
--- a/src/contenttype-data.js
+++ b/src/contenttype-data.js
@@ -25,7 +25,7 @@ class FetchSpecifiedContentTypes extends FetchContentTypes {
     const contentTypes = await fn.apply(null, [url, config, responseKey, query]);
 
     const referredContentTypes = new ReferredContentTypes();
-    const referredContentTypesList = referredContentTypes.getReferredContentTypes(contentTypes); 
+    const referredContentTypesList = referredContentTypes.getReferredContentTypes(contentTypes);
 
     let referredContentTypesData = [];
     if (referredContentTypesList.length) {
@@ -49,7 +49,7 @@ class FetchUnspecifiedContentTypes extends FetchContentTypes {
     const contentTypes = await fn.apply(null, [url, config, responseKey, query]);
 
     const referredContentTypes = new ReferredContentTypes();
-    const referredContentTypesList = referredContentTypes.getReferredContentTypes(contentTypes); 
+    const referredContentTypesList = referredContentTypes.getReferredContentTypes(contentTypes).filter((uid) => !(config.excludeContentTypes || []).includes(uid));
 
     let referredContentTypesData = [];
     if (referredContentTypesList.length) {

--- a/src/entry-data.js
+++ b/src/entry-data.js
@@ -15,7 +15,7 @@ class FetchDefaultEntries extends FetchEntries {
         const assetTokenKey = `${typePrefix.toLowerCase()}-sync-token-asset-${configOptions.api_key}`;
         const [syncEntryToken, syncAssetToken] = await Promise.all([cache.get(entryTokenKey), cache.get(assetTokenKey)])
 
-        
+
         const syncEntryParams = syncEntryToken
           ? { sync_token: syncEntryToken }
           : { init: true, limit: configOptions.limit > 100 ? 50 : configOptions.limit };
@@ -72,7 +72,7 @@ class FetchSpecifiedContentTypesEntries extends FetchEntries {
     try {
       let syncData = {};
       const typePrefix = configOptions.type_prefix || 'Contentstack';
-      const contentTypes = await cache.get(typePrefix);
+      const contentTypes = (await cache.get(typePrefix) || []).filter((ct) => !(configOptions.excludeContentTypes || []).includes(ct.uid));
 
       for (let i = 0; i < contentTypes.length; i++) {
         const contentType = contentTypes[i].uid;
@@ -172,9 +172,9 @@ class FetchSpecifiedLocalesAndContentTypesEntries extends FetchEntries {
     try {
       let syncData = {};
       const typePrefix = configOptions.type_prefix || 'Contentstack';
-      const contentTypes = await cache.get(typePrefix);
+      const contentTypes = (await cache.get(typePrefix) || []).filter((ct) => !(configOptions.excludeContentTypes || []).includes(ct.uid));
       const locales = configOptions.locales;
-  
+
       for (let i = 0; i < contentTypes.length; i++) {
         const contentType = contentTypes[i].uid;
         for (let j = 0; j < locales.length; j++) {


### PR DESCRIPTION
When two plugin instances share the same type_prefix and plugin cache
(e.g. a main stack plus a shared/publisher stack), the instance without
an exclusion list overwrites the cached content-type list, causing the
excluded content types to be synced anyway. This produced duplicate
entries from the shared stack.

Re-apply excludeContentTypes filtering at the points where the cached
content-type list is consumed, so exclusions hold regardless of cache
ordering between instances:

- contenttype-data.js: filter referred content types in
  FetchUnspecifiedContentTypes so references don't re-introduce
  excluded types.
- entry-data.js: filter the cached content types in
  FetchSpecifiedContentTypesEntries and
  FetchSpecifiedLocalesAndContentTypesEntries before entry sync.
