### PR TITLE
fix(deps): override hono, js-yaml and socket.io-parser to patched versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatsby-source-contentstack",
-  "version": "5.4.9",
+  "version": "5.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatsby-source-contentstack",
-      "version": "5.4.9",
+      "version": "5.4.10",
       "license": "MIT",
       "dependencies": {
         "@contentstack/utils": "^1.9.1",
@@ -18174,9 +18174,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -21007,9 +21007,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -29180,9 +29180,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-contentstack",
-  "version": "5.4.9",
+  "version": "5.4.10",
   "description": "Gatsby source plugin for building websites using Contentstack as a data source",
   "scripts": {
     "prepublish": "npm run build",
@@ -97,7 +97,9 @@
     "gatsby": {
       "eslint": "9.26.0"
     },
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
+    "hono": "^4.12.34",
+    "socket.io-parser": "^4.2.7",
     "@eslint/plugin-kit": "^0.3.4",
     "@semantic-release/npm": "^13.1.5"
   },


### PR DESCRIPTION
## Summary

Clears 6 of the 7 vulnerabilities Snyk reports against this project's install tree. Version bumped 5.4.9 → 5.4.10 to match what semantic-release computes for a `fix:` commit.

**Approach:** all six have patched upstream releases, so they are fixed by forcing the patched version through the existing `overrides` block. No `.snyk` ignore added, and no ignore is needed. Confirmed with `npm ls` that each override actually resolved rather than just being declared:

| Package | Before | After | Advisories cleared |
|---|---|---|---|
| `hono` | 4.12.32 | **4.13.1** | `SNYK-JS-HONO-18517010` ReDoS, `-18592332` data exposure to wrong session, `-18592333` HTTP request smuggling, `-18593786` inefficient algorithmic complexity |
| `js-yaml` | 4.3.0 | **4.3.1** | `SNYK-JS-JSYAML-18593780` inefficient algorithmic complexity (High) |
| `socket.io-parser` | 4.2.6 | **4.2.7** | `SNYK-JS-SOCKETIOPARSER-18517008` improper check for unusual conditions (High) |

All three are patch bumps inside the same major, so no API surface moves. `hono` is only present because ESLint 9.26 ships an MCP server that pulls `@modelcontextprotocol/sdk`; nothing in this plugin touches it.

**Left unfixed, deliberately:** `react-dev-utils@12.0.1` — Critical command injection, `SNYK-JS-REACTDEVUTILS-17890708`. 12.0.1 is the latest *stable* release, with only `12.1.0-next` prereleases beyond it, and it is a direct dependency of `gatsby@5.16.1`, itself the latest stable gatsby. There is no version to override to. Snyk's own output says "No upgrade or patch available". This clears when gatsby moves off it.

**Scope note:** every package here arrives through `gatsby`, which is a `peerDependency`. None of them are published with this plugin — the published tarball carries only the 9 runtime `dependencies`, and a consuming project supplies its own Gatsby tree, which these overrides do not reach. This change makes the project's own scan honest; it does not change what consumers install.

## Test plan

- [x] `snyk test` before: **7 vulnerabilities** (1 critical, 2 high, 4 medium). After: **1** (the react-dev-utils critical above).
- [x] `npm ls hono js-yaml socket.io-parser` — each reports `overridden` at the patched version, not the declared one.
- [x] `npx jest` — 6 suites, 16 tests, all pass.
- [x] `npm run build` — 25 files compiled, no change to committed build output.
- [x] `git status` clean apart from `package.json` and `package-lock.json` (3 lines and 9 lines respectively).

Not covered: no live verification against a real Contentstack stack, since no plugin source changed — this is dependency resolution only. The 11 remaining Snyk *license* findings (MPL-2.0 in `axe-core`, LGPL-3.0 in the `sharp-libvips` platform binaries) are pre-existing and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)